### PR TITLE
Added new controls in Properties panel

### DIFF
--- a/src/legacy/dev-application/layouts/scripts/main-creator.phtml
+++ b/src/legacy/dev-application/layouts/scripts/main-creator.phtml
@@ -79,7 +79,6 @@
   <script type="text/javascript" src="/js/jquery/jquery.ui.touch-punch.min.js"></script>
 
   <script type="text/javascript" src="/js/jquery/thickbox.js"></script>
-  <script language="JavaScript" type="text/javascript" src="/js/wysiwyg/tiny_mce/tiny_mce.js"></script>
   <?php echo $this->headScript(); ?>
 </head>
 <body id="body" class="overflow-hidden">

--- a/src/legacy/dev-application/layouts/scripts/main.phtml
+++ b/src/legacy/dev-application/layouts/scripts/main.phtml
@@ -56,10 +56,6 @@
   <script type="text/javascript" src="/js/jquery/jquery-1.3.2.min.js"></script>
   <script type="text/javascript" src="/js/combinedAll.js" ></script>
 
-
-  <!-- <script type="text/javascript" src="/js/js/easySlider1.5.js"></script> -->
-  <!-- <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.5.3/jquery-ui.min.js" ></script> -->
-
 </head>
 <body style="background:<?php echo $this->templateBodyBackground;?>;" class="overflow-x-hidden w-full min-h-dvh h-auto bg-cover">
   <div class="top"></div>
@@ -68,7 +64,6 @@
       <div id="content">
         <?php
         echo $this->layout()->content;
-        //echo $this->layout()->ajaxContent ;
         ?>
       </div>
     </div>
@@ -87,6 +82,7 @@
   }
   ?>
   <script type="text/javascript">
+    /* add DaisyUI fixes */
     $('select').addClass('select-sm shadow-sm');
     $('input').each(function(){
       $(this).addClass('input input-sm w-full shadow-sm').attr('placeholder', $(this).attr('name'));
@@ -96,7 +92,12 @@
       collapsed: true,
       animated: "medium"
     });
-
+    $.each( $('.jd_menu'), function(k,v){
+        const parentBackgroundColor = $(this).closest('.templateDiv').css('background-color');
+        const parentFontColor = $(this).closest('.templateDiv').css('color');
+        $(this).find('li').css('background-color', parentBackgroundColor);
+        $(this).find('a.link').css('color', parentFontColor);
+    });
   </script>
 </body>
 </html>

--- a/src/legacy/dev-application/views/scripts/creator/creator.js
+++ b/src/legacy/dev-application/views/scripts/creator/creator.js
@@ -3591,6 +3591,9 @@ fsElement2 = document.getElementById('fragment-8wrapper');
 var fsButton3 = document.getElementById('fsbutton3');
 fsElement3 = document.getElementById('fragment-5wrapper');
 
+var fsButtonHtml = document.getElementById('fsbuttonHtml');
+fsElementHtml = document.getElementById('selected-object-html-wrapper');
+
 var fsButtonAll = document.getElementById('fsbuttonAll');
 fsElementAll = document.getElementById('body');
 
@@ -3713,6 +3716,26 @@ fsButton3.addEventListener('click', function(e) {
   $('.ui-dialog').livequery(function(){
     if(window.fullScreen == 1){
       $(this).appendTo(fsElement3);
+    }
+  });
+
+}, true);
+
+//edit HTML in FS
+fsButtonHtml.addEventListener('click', function(e) {
+  e.preventDefault();
+  // if already in fullscreen, it needs to get out of it
+  if( $(fsElementHtml).hasClass('fs') === true ){
+    window.fullScreenApi.cancelFullScreen(fsElementHtml);
+    $(fsElementHtml).removeClass('fs');
+    return;
+  }
+
+  window.fullScreenApi.requestFullScreen(fsElementHtml);
+  $(fsElementHtml).addClass('fs').find('iframe').height($(window).height());
+  $('.ui-dialog').livequery(function(){
+    if(window.fullScreen == 1){
+      $(this).appendTo(fsElementHtml);
     }
   });
 

--- a/src/legacy/dev-application/views/scripts/creator/creator.js
+++ b/src/legacy/dev-application/views/scripts/creator/creator.js
@@ -31,6 +31,51 @@ $('.navLinks').click( function(){
   $('.currentTitle').removeClass('currentTitle');
   $(this).addClass('currentTitle');
 });
+$('#toggleFontWeight').click( function(){
+  setBold();
+});
+$('#toggleFontStyle').click( function(){
+  setItalic();
+});
+$('#toggleUnderline').click( function(){
+  setUnderline();
+});
+$('#toggleTextCenter').click( function(){
+  setTextAlign('center');
+});
+$('#toggleTextLeft').click( function(){
+  setTextAlign('left');
+});
+$('#toggleTextRight').click( function(){
+  setTextAlign('right');
+});
+$('#selected-object-position').change(function(){
+  $('.selected-for-append').css( 'position', $(this).val() );
+});
+/* functions for setting styles of selected text */
+function setBold(){
+  const strong = document.createElement("strong");
+  const selectedText = window.getSelection();
+  const selectedTextRange = selectedText.getRangeAt(0);
+  selectedTextRange.surroundContents(strong);
+}
+function setItalic(){
+  const italic = document.createElement("i");
+  const selectedText = window.getSelection();
+  const selectedTextRange = selectedText.getRangeAt(0);
+  selectedTextRange.surroundContents(italic);
+}
+function setUnderline(){
+  const span = document.createElement("span");
+  const selectedText = window.getSelection();
+  const selectedTextRange = selectedText.getRangeAt(0);
+  selectedTextRange.surroundContents(span);
+  span.style.textDecoration = 'underline';
+}
+function setTextAlign(align){
+  $('.selected-for-append').css('text-align', align);
+}
+
 function dialog(){
 
   if (screen.width == window.innerWidth && screen.height == window.innerHeight) {
@@ -1271,6 +1316,7 @@ $(".draggable").livequery('dblclick', function(e){
   $(this).removeClass("inactiveObject");
   $(this).addClass("activeObject");
 
+  const position = $(e.target).css('position');
   width = $(e.target).css("width");
   height= $(e.target).css("height");
   border = $(e.target).css("border");
@@ -1329,6 +1375,7 @@ $(".draggable").livequery('dblclick', function(e){
   $("#objPropertiesFontColor").closest('.clr-field').css({ color: fontColor });
 
   $("#objPropertiesBackgroundImage").val( bgImage );
+  $("#selected-object-position").val( position );
   //objTheme
   $('#objTheme').val( themeClass);
   $('#objTheme').val(themeClass);

--- a/src/legacy/dev-application/views/scripts/creator/creator.js
+++ b/src/legacy/dev-application/views/scripts/creator/creator.js
@@ -591,7 +591,7 @@ $(document).ready(function(){
         let currentClass = item;
         if( currentClass === '' || currentClass == 'selected-for-append') return;
 
-        objectClassesFields = objectClassesFields + '<div class="inline-flex gap-2 items-center max-w-80"><input type="checkbox" class="checkbox-sm classes-toggle" checked="true" value="' + currentClass + '" /><span style="overflow-wrap: break-word;inline-size: 9rem;">' + currentClass + '</span></div>';
+        objectClassesFields = objectClassesFields + '<div class="inline-flex gap-2 items-center max-w-80"><input type="checkbox" class="checkbox-sm checkbox classes-toggle" checked="true" value="' + currentClass + '" /><span style="overflow-wrap: break-word;inline-size: 9rem;">' + currentClass + '</span></div>';
       });
 
       // create the part in ID assistenat that holds classes and their checkboxes
@@ -618,11 +618,9 @@ $(document).ready(function(){
   // toggling classes for the object that ID assistant is pointing to
   $('.classes-toggle').livequery('change', function(e){
 
-    if($(e.target).attr('checked') === undefined) {
-
+    if( e.target.checked === false ) {
       $( '#' + $('#assistant-target-id').text()).removeClass($(e.target).val());
     } else {
-
       $( '#' + $('#assistant-target-id').text()).addClass($(e.target).val());
     }
   });

--- a/src/legacy/dev-application/views/scripts/creator/index.phtml
+++ b/src/legacy/dev-application/views/scripts/creator/index.phtml
@@ -108,13 +108,6 @@
 
             <div class="grid">  
               <div class="grid gap-2">
-
-                <!-- <div id="p_t_common" class="noAjaxEvent flex item-strech gap-2 items-center h-6">
-
-                  <span><?php echo $this->translate->_("Page");?></span><span><input id="pageDisplayer" class="noAjaxEvent help radio-sm" type="radio" name="p_g" value="pageEditing" checked="checked" title="<?php echo $this->translate->_("Page creating Mode");?>" /></span>
-                  <span><?php echo $this->translate->_("Template");?></span><span><input  id="templateDisplayer" class="noAjaxEvent help radio-sm" type="radio" name="p_g" value="templateEditing" title="<?php echo $this->translate->_("Template creating Mode");?>" /></span>
-                </div> -->
-
                 <div class="" >
                   <?php echo $this->langChooserAdmin;?>
                 </div>
@@ -250,6 +243,53 @@
                 <span class="cl col-span-3 justify-self-start">FontColor:</span><span><input id="objPropertiesFontColor" name="objPropertiesFontColor"class="input w-16 max-h-5 p-0" type="text" value="" data-coloris /></span>
 
                 <span class="cl col-span-3 justify-self-start">BgImage:</span><span><input id="objPropertiesBackgroundImage" name="objPropertiesBackgroundImage"class="input w-16 max-h-5 p-0" type="text" value="" /></span>
+                <span class="cl col-span-3 justify-self-start">Position:</span><span>
+                  <select name="selected-object-position" id="selected-object-position" class="help select select-xs w-full" title="Set the position of the selected object." size="1">
+                      <option value="static" selected="selected">Static</option>
+                      <option value="relative">Relative</option>
+                      <option value="fixed">Fixed</option>
+                      <option value="absolute">Absolute</option>
+                      <option value="sticky">Sticky</option>
+                  </select>
+                </span>
+
+                <span class="w-full col-span-4 justify-self-start mt-2">
+                  <div class="grid grid-cols-6 justify-items-center">
+                    <div id="toggleFontWeight" class="help cursor-pointer btn btn-sm btn-ghost btn-circle text-white" title="Click to toggle font-weight">
+                      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="w-4 h-4">
+                        <path fill-rule="evenodd" d="M5.246 3.744a.75.75 0 0 1 .75-.75h7.125a4.875 4.875 0 0 1 3.346 8.422 5.25 5.25 0 0 1-2.97 9.58h-7.5a.75.75 0 0 1-.75-.75V3.744Zm7.125 6.75a2.625 2.625 0 0 0 0-5.25H8.246v5.25h4.125Zm-4.125 2.251v6h4.5a3 3 0 0 0 0-6h-4.5Z" clip-rule="evenodd" />
+                      </svg>
+                    </div>
+
+                    <div id="toggleFontStyle" class="help cursor-pointer btn btn-sm btn-ghost btn-circle text-white" title="Click to toggle font-style">
+                      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="w-4 h-4">
+                        <path fill-rule="evenodd" d="M10.497 3.744a.75.75 0 0 1 .75-.75h7.5a.75.75 0 0 1 0 1.5h-3.275l-5.357 15.002h2.632a.75.75 0 1 1 0 1.5h-7.5a.75.75 0 1 1 0-1.5h3.275l5.357-15.002h-2.632a.75.75 0 0 1-.75-.75Z" clip-rule="evenodd" />
+                      </svg>
+                    </div>
+
+                    <div id="toggleUnderline" class="help cursor-pointer btn btn-sm btn-ghost btn-circle text-white" title="Click to toggle underline">
+                      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="w-4 h-4">
+                        <path fill-rule="evenodd" d="M5.995 2.994a.75.75 0 0 1 .75.75v7.5a5.25 5.25 0 1 0 10.5 0v-7.5a.75.75 0 0 1 1.5 0v7.5a6.75 6.75 0 1 1-13.5 0v-7.5a.75.75 0 0 1 .75-.75Zm-3 17.252a.75.75 0 0 1 .75-.75h16.5a.75.75 0 0 1 0 1.5h-16.5a.75.75 0 0 1-.75-.75Z" clip-rule="evenodd" />
+                      </svg>
+                    </div>
+                    <div id="toggleTextCenter" class="help cursor-pointer btn btn-sm btn-ghost btn-circle text-white" title="Click to toggle underline">
+                      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="size-4">
+                        <path fill-rule="evenodd" d="M3 6.75A.75.75 0 0 1 3.75 6h16.5a.75.75 0 0 1 0 1.5H3.75A.75.75 0 0 1 3 6.75ZM3 12a.75.75 0 0 1 .75-.75h16.5a.75.75 0 0 1 0 1.5H3.75A.75.75 0 0 1 3 12Zm0 5.25a.75.75 0 0 1 .75-.75h16.5a.75.75 0 0 1 0 1.5H3.75a.75.75 0 0 1-.75-.75Z" clip-rule="evenodd" />
+                      </svg>
+                    </div>
+                    <div id="toggleTextLeft" class="help cursor-pointer btn btn-sm btn-ghost btn-circle text-white" title="Click to toggle underline">
+                      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="size-4">
+                        <path fill-rule="evenodd" d="M3 6.75A.75.75 0 0 1 3.75 6h16.5a.75.75 0 0 1 0 1.5H3.75A.75.75 0 0 1 3 6.75ZM3 12a.75.75 0 0 1 .75-.75h16.5a.75.75 0 0 1 0 1.5H3.75A.75.75 0 0 1 3 12Zm0 5.25a.75.75 0 0 1 .75-.75H12a.75.75 0 0 1 0 1.5H3.75a.75.75 0 0 1-.75-.75Z" clip-rule="evenodd" />
+                      </svg>
+                    </div>
+                    <div id="toggleTextRight" class="help cursor-pointer btn btn-sm btn-ghost btn-circle text-white" title="Click to toggle underline">
+                      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="size-4">
+                        <path fill-rule="evenodd" d="M3 6.75A.75.75 0 0 1 3.75 6h16.5a.75.75 0 0 1 0 1.5H3.75A.75.75 0 0 1 3 6.75ZM3 12a.75.75 0 0 1 .75-.75h16.5a.75.75 0 0 1 0 1.5H3.75A.75.75 0 0 1 3 12Zm8.25 5.25a.75.75 0 0 1 .75-.75h8.25a.75.75 0 0 1 0 1.5H12a.75.75 0 0 1-.75-.75Z" clip-rule="evenodd" />
+                      </svg>
+                    </div>
+                  </div>
+                </span>
+
                 <!-- classes are to be handled through former ID assistant -->
                 <div id="id-assistant-container"></div>
                 <div class="hidden"><span class="cl col-span-4 justify-self-start">class:</span><span class="col-span-4 w-full"><input id="objPropertiesClass" name="objPropertiesClass"class="input w-full max-h-8 p-0" type="text" value="" /></span></div>

--- a/src/legacy/dev-application/views/scripts/creator/index.phtml
+++ b/src/legacy/dev-application/views/scripts/creator/index.phtml
@@ -138,7 +138,7 @@
                 </div>
                 <div class="flex flex-col min-h-32">
                   <?php echo $this->translate->_("HTML of this object");?>:
-                  <textarea id="objPropertiesHtmlSelected" name="objPropertiesHtmlSelected" class="min-h-32"></textarea>
+                  <textarea id="objPropertiesHtmlSelected" name="objPropertiesHtmlSelected" class="textarea min-h-32"></textarea>
                   <a href="" id="applyHtml" class="navLinks noAjaxEvent btn btn-secondary btn-sm md:btn-xs mb-2 help" title="<?php echo $this->translate->_("Click to apply this HTML to the selected object");?>">Apply</a>
                 </div>
 
@@ -175,21 +175,21 @@
             <div class="grid place-items-strech gap-4" >
               <div class="grid gap-y-2 content-start">
                 <div class="grid mt-1 gap-y-2 h-24">
-                  <div class="creatorDiv grid grid-cols-2 items-strech"><span class="cl"><?php echo $this->translate->_("ID Assistant");?></span><span><input id="tttoggle" type="checkbox"  class="checkbox-sm float-right" checked="false" /></span></div>
-                  <div class="creatorDiv grid grid-cols-2 items-strech"><span class="cl"><?php echo $this->translate->_("Show hidden");?>:</span><span><input id="showFooterCheck" name="showFooterCheck" type="checkbox" class="checkbox-sm float-right" /></span></div>
+                  <div class="creatorDiv grid grid-cols-2 items-strech"><span class="cl"><?php echo $this->translate->_("ID Assistant");?></span><span><input id="tttoggle" type="checkbox"  class="checkbox-sm checkbox float-right" checked="false" /></span></div>
+                  <div class="creatorDiv grid grid-cols-2 items-strech"><span class="cl"><?php echo $this->translate->_("Show hidden");?>:</span><span><input id="showFooterCheck" name="showFooterCheck" type="checkbox" class="checkbox-sm checkbox float-right" /></span></div>
                   <div class="creatorDiv grid grid-cols-4 items-strech"><span class="cl col-span-3"><?php echo $this->translate->_("Shadow");?></span><span> <a href="" class="navLinks help a_params noAjaxEvent currentTitle" id="aParamShadow" title="<?php echo $this->translate->_("Click to set shadow params");?>">
                     <svg class="w-4 h-4 fill-current bg-secondary text-white rounded-full inline-block" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
                       <path d="M16.5 6a3 3 0 0 0-3-3H6a3 3 0 0 0-3 3v7.5a3 3 0 0 0 3 3v-6A4.5 4.5 0 0 1 10.5 6h6Z" />
                       <path d="M18 7.5a3 3 0 0 1 3 3V18a3 3 0 0 1-3 3h-7.5a3 3 0 0 1-3-3v-7.5a3 3 0 0 1 3-3H18Z" />
                     </svg>
                     <div class="hidden">Shadow</div>
-                  </a><input id="shadowCheck" type="checkbox" class="checkbox-sm float-right"  /></span></div>
+                  </a><input id="shadowCheck" type="checkbox" class="checkbox-sm checkbox float-right"  /></span></div>
                   <div class="creatorDiv grid grid-cols-4 items-strech"><span class="cl col-span-3"><?php echo $this->translate->_("Corner");?></span><span> <a href="" class="navLinks help a_params noAjaxEvent currentTitle content-center h-6 inline-block" id="aParamCorner" title="<?php echo $this->translate->_("Click to set corner params");?>">
                     <svg class="w-4 h-4 fill-current text-white rounded" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" >
                       <path d="M6 3a3 3 0 0 0-3 3v1.5a.75.75 0 0 0 1.5 0V6A1.5 1.5 0 0 1 6 4.5h1.5a.75.75 0 0 0 0-1.5H6ZM16.5 3a.75.75 0 0 0 0 1.5H18A1.5 1.5 0 0 1 19.5 6v1.5a.75.75 0 0 0 1.5 0V6a3 3 0 0 0-3-3h-1.5ZM12 8.25a3.75 3.75 0 1 0 0 7.5 3.75 3.75 0 0 0 0-7.5ZM4.5 16.5a.75.75 0 0 0-1.5 0V18a3 3 0 0 0 3 3h1.5a.75.75 0 0 0 0-1.5H6A1.5 1.5 0 0 1 4.5 18v-1.5ZM21 16.5a.75.75 0 0 0-1.5 0V18a1.5 1.5 0 0 1-1.5 1.5h-1.5a.75.75 0 0 0 0 1.5H18a3 3 0 0 0 3-3v-1.5Z" />
                     </svg>
                     <div class="hidden">Corner</div>
-                  </a><input id="cornerCheck" type="checkbox" class="checkbox-sm float-right"  /></span></div>
+                  </a><input id="cornerCheck" type="checkbox" class="checkbox-sm checkbox float-right"  /></span></div>
                 </div>
 
                 <div id="fontCont" style="display:none;">
@@ -230,7 +230,7 @@
                 </div>-->
               </div>
 
-              <div class="grid grid-cols-4 h-64 items-strech justify-items-end">
+              <div class="grid grid-cols-4 h-96 items-strech justify-items-end">
                 <span class="cl col-span-3 justify-self-start"><?php echo $this->translate->_("Width");?>:</span><span><input id="objPropertiesWidth" name="objPropertiesWidth"class="input w-16 max-h-5 p-0" type="text" value="" /></span>
                 <span class="cl col-span-3 justify-self-start"><?php echo $this->translate->_("Height");?>:</span><span><input id="objPropertiesHeight" name="objPropertiesHeight"class="input w-16 max-h-5 p-0" type="text" value="" /></span>
                 <span class="cl col-span-3 justify-self-start"><?php echo $this->translate->_("Border");?>:</span><span><input id="objPropertiesBorder" name="objPropertiesBorder"class="input w-16 max-h-5 p-0" type="text" value="" /></span>
@@ -244,7 +244,7 @@
 
                 <span class="cl col-span-3 justify-self-start">BgImage:</span><span><input id="objPropertiesBackgroundImage" name="objPropertiesBackgroundImage"class="input w-16 max-h-5 p-0" type="text" value="" /></span>
                 <span class="cl col-span-3 justify-self-start">Position:</span><span>
-                  <select name="selected-object-position" id="selected-object-position" class="help select select-xs w-full" title="Set the position of the selected object." size="1">
+                  <select name="selected-object-position" id="selected-object-position" class="help select select-xs w-16" title="Set the position of the selected object." size="1">
                       <option value="static" selected="selected">Static</option>
                       <option value="relative">Relative</option>
                       <option value="fixed">Fixed</option>
@@ -309,15 +309,15 @@
 
                   <div class="w-full">
 
-                    <div class="creatorDiv inline-flex gap-2 items-center w-full"><input id="allLangCheck" type="checkbox" class="checkbox-sm" /><?php echo $this->translate->_("Apply to all languages");?></div>
+                    <div class="creatorDiv inline-flex gap-2 items-center w-full"><input id="allLangCheck" type="checkbox" class="checkbox-sm checkbox" /><?php echo $this->translate->_("Apply to all languages");?></div>
 
-                    <div id="restrictiveDiv" class="inline-flex gap-2 items-center w-full"><input id="restrictiveCB" type="checkbox" class="checkbox-sm"  /><?php echo $this->translate->_("Restrictive");?> 
+                    <div id="restrictiveDiv" class="inline-flex gap-2 items-center w-full"><input id="restrictiveCB" type="checkbox" class="checkbox-sm checkbox"  /><?php echo $this->translate->_("Restrictive");?>
                     <a href="" style="display:none" id="openPagePermisions" class="navLinks a_access btn btn-xs btn-secondary" title="<?php echo $this->translate->_("Click to set permissions for this page");?>"><?php echo $this->translate->_("Permissions");?></a>
                     <div id="allowedRolesDiv" class="w-full p-2"></div>
                   </div>
 
                   <div id="boundDiv" class="inline-flex gap-2 items-center w-full">
-                    <input id="boundCB" type="checkbox" checked="checked" class="checkbox-sm" /><?php echo $this->translate->_("Relative to Content Area");?> 
+                    <input id="boundCB" type="checkbox" checked="checked" class="checkbox-sm checkbox" /><?php echo $this->translate->_("Relative to Content Area");?>
                   </div>
 
                 </div>
@@ -346,8 +346,8 @@
                   <a href="" id="applyTemplate" class="navLinks a_edit btn btn-secondary btn-sm md:btn-xs" title="<?php echo $this->translate->_("Click to edit existing template");?>"><?php echo $this->translate->_("Edit template");?></a>
                   <a href="" id="saveThisTemplate" class="navLinks a_save btn btn-secondary btn-sm md:btn-xs" title="<?php echo $this->translate->_("Click to save work on this template");?>"><?php echo $this->translate->_("Save Template");?></a>
                   <a href="" id="saveAsTemplate" class="navLinks a_save_new btn btn-secondary btn-sm md:btn-xs"  title="<?php echo $this->translate->_("Click to save this work as template");?>"><?php echo $this->translate->_("Save As New Template");?></a>
-                  <div class="creatorDiv inline-flex gap-2 items-center"><input id="allLangCheckTemplate" class="checkbox-sm" type="checkbox" /><?php echo $this->translate->_("Apply to all languages");?></div>
-                  <div id="DefaultTemplateChangerDiv" class="inline-flex gap-2 items-center"><input id="templateDefaultCB" class="checkbox-sm" type="checkbox" name="templateDefaultCB" /><?php echo $this->translate->_("Default Template");?></div>
+                  <div class="creatorDiv inline-flex gap-2 items-center"><input id="allLangCheckTemplate" class="checkbox-sm checkbox" type="checkbox" /><?php echo $this->translate->_("Apply to all languages");?></div>
+                  <div id="DefaultTemplateChangerDiv" class="inline-flex gap-2 items-center"><input id="templateDefaultCB" class="checkbox-sm checkbox" type="checkbox" name="templateDefaultCB" /><?php echo $this->translate->_("Default Template");?></div>
 
                   <a href="" id="exportTemplate" class="navLinks a_edit btn btn-secondary btn-sm md:btn-xs" title="<?php echo $this->translate->_("Click to export this template for use on another installation.");?>"><?php echo $this->translate->_("Export Template");?></a>
                   <a href="" id="installTemplate" class="navLinks a_save btn btn-secondary btn-sm md:btn-xs" title="<?php echo $this->translate->_("Click to install exported template");?>"><?php echo $this->translate->_("Install Template");?></a>
@@ -389,7 +389,7 @@
           <div id="menuShow" class="grid gap-2 content-start">
 
             <div class="inline-flex items-center gap-2">
-              <?php echo $this->translate->_("Put in this object");?> <input id="putInThis" class="checkbox-sm" type="checkbox" />
+              <?php echo $this->translate->_("Put in this object");?> <input id="putInThis" class="checkbox-sm checkbox" type="checkbox" />
             </div>
 
             <div class="grid items-center gap-2">
@@ -432,7 +432,7 @@
         <div id="categoryFormContainer" class="grid gap-4" >
           <div class="grid gap-2 content-start">
             <div>
-              <?php echo $this->translate->_("Put in this object");?> <input id="putCategoryInThis" class="checkbox-sm" type="checkbox" />
+              <?php echo $this->translate->_("Put in this object");?> <input id="putCategoryInThis" class="checkbox-sm checkbox" type="checkbox" />
             </div>
 
             <div id="categoryShow">
@@ -494,7 +494,7 @@
               </div>
 
               <div id="modulesShow">
-                <div style="display:none;"><?php echo $this->translate->_("Put in this object");?> <input id="putModulesInThis" class="checkbox-sm" type="checkbox" /></div>
+                <div style="display:none;"><?php echo $this->translate->_("Put in this object");?> <input id="putModulesInThis" class="checkbox-sm checkbox" type="checkbox" /></div>
 
                 <?php echo $this->formChooseModules;?>
               </div>
@@ -550,16 +550,16 @@
 
         <a id="setBodyBgImage" class="a_add marginBottom5 btn btn-sm md:btn-xs" style="display:none" title="<?php echo $this->translate->_("Click to set background");?>"><?php echo $this->translate->_("Set background");?> </a>
 
-        <div>
-          <?php echo $this->translate->_("Put image(s) in the selected object");?> <input id="putImagesInThis" class="checkbox-sm" type="checkbox" /> into the
+        <div class="inline-flex gap-2 items-center">
+          <?php echo $this->translate->_("Put image(s) in the selected object");?> <input id="putImagesInThis" class="checkbox-sm checkbox" type="checkbox" /> into the
           <!--<?php echo $this->translate->_("Single Image");?><input id="putSingleImageInThis" type="checkbox" />-->
         </div>
 
         <select id="bgSelect" class="help select select-sm md:select-xs w-full" title="<?php echo $this->translate->_("For this to work, set appropriate classes to the objects, lowercase (HEADER = header) except for the BODY, body is always there." );?>"><option>BODY</option><option>HEADER</option><option>SHEET</option><option>LEFTCOLUMN</option><option>RIGHTCOLUMN</option><option>FOOTER</option><option>SELECTED-OBJECT</option></select>
         
-        <div>
-          <input type="checkbox" class="checkbox-sm" name="NR" value="repeat" id="NR" /> no-repeat
-          <input type="checkbox" class="checkbox-sm" name="fixedBg" value="fixed"  id="fixedBg" /> Fixed
+        <div class="inline-flex gap-2 items-center">
+          <input type="checkbox" class="checkbox-sm checkbox" name="NR" value="repeat" id="NR" /> no-repeat
+          <input type="checkbox" class="checkbox-sm checkbox" name="fixedBg" value="fixed"  id="fixedBg" /> Fixed
         </div>
 
         <!--Image path:-->

--- a/src/legacy/dev-application/views/scripts/creator/index.phtml
+++ b/src/legacy/dev-application/views/scripts/creator/index.phtml
@@ -136,8 +136,17 @@
                   <textarea id="objPropertiesHtmlTiny" name="objPropertiesHtmlTiny" style="height:100px;">
                   </textarea>
                 </div>
-                <div class="flex flex-col min-h-32">
-                  <?php echo $this->translate->_("HTML of this object");?>:
+                <div id="selected-object-html-wrapper" class="flex flex-col min-h-32 bg-primary">
+                  <div class="grid grid-cols-4 ">
+                    <div class="col-span-3"><?php echo $this->translate->_("HTML of this object");?>:</div>
+                    <div class="justify-self-end mr-1 mb-1">
+                      <a href="#" class="help fsbutton w-8" id="fsbuttonHtml">
+                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="w-4 h-4">
+                          <path fill-rule="evenodd" d="M15 3.75a.75.75 0 0 1 .75-.75h4.5a.75.75 0 0 1 .75.75v4.5a.75.75 0 0 1-1.5 0V5.56l-3.97 3.97a.75.75 0 1 1-1.06-1.06l3.97-3.97h-2.69a.75.75 0 0 1-.75-.75Zm-12 0A.75.75 0 0 1 3.75 3h4.5a.75.75 0 0 1 0 1.5H5.56l3.97 3.97a.75.75 0 0 1-1.06 1.06L4.5 5.56v2.69a.75.75 0 0 1-1.5 0v-4.5Zm11.47 11.78a.75.75 0 1 1 1.06-1.06l3.97 3.97v-2.69a.75.75 0 0 1 1.5 0v4.5a.75.75 0 0 1-.75.75h-4.5a.75.75 0 0 1 0-1.5h2.69l-3.97-3.97Zm-4.94-1.06a.75.75 0 0 1 0 1.06L5.56 19.5h2.69a.75.75 0 0 1 0 1.5h-4.5a.75.75 0 0 1-.75-.75v-4.5a.75.75 0 0 1 1.5 0v2.69l3.97-3.97a.75.75 0 0 1 1.06 0Z" clip-rule="evenodd"></path>
+                        </svg>
+                      </a>
+                    </div>
+                  </div>
                   <textarea id="objPropertiesHtmlSelected" name="objPropertiesHtmlSelected" class="textarea min-h-32"></textarea>
                   <a href="" id="applyHtml" class="navLinks noAjaxEvent btn btn-secondary btn-sm md:btn-xs mb-2 help" title="<?php echo $this->translate->_("Click to apply this HTML to the selected object");?>">Apply</a>
                 </div>
@@ -555,7 +564,7 @@
           <!--<?php echo $this->translate->_("Single Image");?><input id="putSingleImageInThis" type="checkbox" />-->
         </div>
 
-        <select id="bgSelect" class="help select select-sm md:select-xs w-full" title="<?php echo $this->translate->_("For this to work, set appropriate classes to the objects, lowercase (HEADER = header) except for the BODY, body is always there." );?>"><option>BODY</option><option>HEADER</option><option>SHEET</option><option>LEFTCOLUMN</option><option>RIGHTCOLUMN</option><option>FOOTER</option><option>SELECTED-OBJECT</option></select>
+        <select id="bgSelect" class="help select select-sm md:select-xs w-full" title="<?php echo $this->translate->_("For this to work, set appropriate classes to the objects, lowercase (HEADER = header) except for the BODY, body is always there." );?>"><option>BODY</option><option>HEADER</option><option>SHEET</option><option>LEFTCOLUMN</option><option>RIGHTCOLUMN</option><option>FOOTER</option><option selected="selected">SELECTED-OBJECT</option></select>
         
         <div class="inline-flex gap-2 items-center">
           <input type="checkbox" class="checkbox-sm checkbox" name="NR" value="repeat" id="NR" /> no-repeat

--- a/src/legacy/dev-application/widgets/templates/jdMenu.phtml
+++ b/src/legacy/dev-application/widgets/templates/jdMenu.phtml
@@ -16,7 +16,7 @@
  * 
  */
  ?>
-<ul class=" jd_menu jd_menu_slate grid grid-cols-6 xl:grid-cols-10 justify-items-stretch w-full bg-primary text-center">
+<ul class=" jd_menu jd_menu_slate grid grid-cols-6 xl:grid-cols-10 justify-items-stretch w-full  text-center">
 <?php
 
 $menu_items = $this->menu_items;
@@ -33,7 +33,7 @@ foreach(@$this->menus as $menus => $k){
     } else {
         $link = '/' . $k['url'];
     }
-    echo '<li class="group transition ease-in duration-200 bg-primary hover:bg-accent rounded pr-2 min-w-fit col-span-12 md:col-span-2 lg:col-span-1 w-full md:w-auto grid grid-cols-12">';
+    echo '<li class="group transition ease-in duration-200 hover:bg-accent rounded pr-2 min-w-fit col-span-12 md:col-span-2 lg:col-span-1 w-full md:w-auto grid grid-cols-12">';
     //generate link if there is such
     if ($k['url'] != '' ) {
         echo '<a class="link col-span-10 p-2" target="' .$target . '" ' . $linkType. '="'  . $link . '" >'.$k['name'].'</a>';
@@ -51,7 +51,7 @@ foreach(@$this->menus as $menus => $k){
                 $link = '/' . $s['url'];
             }
 
-            echo '<li id="'.$s['item_id'].'" class="group transition ease-in duration-200 bg-primary hover:bg-accent rounded pr-2 w-full md:w-auto grid grid-cols-12"><a ' . $linkType. '="'  . $link . '"  target="' .$target . '" class="link col-span-10 p-2"   >' . $s['name'] . '</a> ';
+            echo '<li id="'.$s['item_id'].'" class="group transition ease-in duration-200 hover:bg-accent hover:bg-accent rounded pr-2 w-full md:w-auto grid grid-cols-12"><a ' . $linkType. '="'  . $link . '"  target="' .$target . '" class="link col-span-10 p-2"   >' . $s['name'] . '</a> ';
             // SUBLEVEL 2
             if ( @$menu_items[$s['item_id']] !== null ) {
                 echo '<span class="submenu-pointer grid col-span-2 justify-self-end items-center self-center justify-items-center rounded-full text-neutral-content  right-1 top-1 w-4 h-4 text-xs"></span><ul class="min-w-48 w-full md:w-auto grid grid-cols-12 shadow-lg">';
@@ -63,7 +63,7 @@ foreach(@$this->menus as $menus => $k){
                         $link = '/' . $s2['url'];
                     }
 
-                    echo '<li id="'.$s2['item_id'].'" class="group transition ease-in duration-200 bg-primary hover:bg-accent rounded pr-2 w-full md:w-auto grid grid-cols-12"><a ' . $linkType. '="'  . $link . '"  target="' .$target . '" class="link col-span-10 p-2"   >' . $s2['name'] . '</a> ';
+                    echo '<li id="'.$s2['item_id'].'" class="group transition ease-in duration-200 hover:bg-accent rounded pr-2 w-full md:w-auto grid grid-cols-12"><a ' . $linkType. '="'  . $link . '"  target="' .$target . '" class="link col-span-10 p-2"   >' . $s2['name'] . '</a> ';
 
                     //SUBLEVEL 3
                     if ( @$menu_items[$s2['item_id']] !== null ) {
@@ -74,7 +74,7 @@ foreach(@$this->menus as $menus => $k){
                             } else {
                                 $link = '/' . $s3['url'];
                             }
-                            echo '<li id="'.$s3['item_id'].'" class="group transition ease-in duration-200 bg-primary hover:bg-accent rounded pr-2 w-full md:w-auto grid grid-cols-12"><a ' . $linkType. '="'  . $link . '"  target="' .$target . '" class="link col-span-10 p-2"   >' . $s3['name'] . '</a> ';
+                            echo '<li id="'.$s3['item_id'].'" class="group transition ease-in duration-200 hover:bg-accent rounded pr-2 w-full md:w-auto grid grid-cols-12"><a ' . $linkType. '="'  . $link . '"  target="' .$target . '" class="link col-span-10 p-2"   >' . $s3['name'] . '</a> ';
 
                             echo '</li>';
                         }

--- a/src/legacy/dev-application/widgets/templates/jdMenuVertical.phtml
+++ b/src/legacy/dev-application/widgets/templates/jdMenuVertical.phtml
@@ -17,7 +17,7 @@
  */
  ?>
 <!--jd_menu jd_menu_vertical -->
-<ul class=" jd_menu jd_menu_vertical w-full rounded-lg bg-primary p-1" style="">
+<ul class=" jd_menu jd_menu_vertical w-full rounded-lg p-1" style="">
 <?php
 
 $menu_items = $this->menu_items;
@@ -34,7 +34,7 @@ foreach(@$this->menus as $menus => $k){
     } else {
         $link = '/' . $k['url'];
     }
-    echo '<li class="group transition ease-in duration-200 bg-primary hover:bg-accent rounded relative pr-8">';
+    echo '<li class="group transition ease-in duration-200 hover:bg-accent rounded relative pr-8">';
     //generate link if there is such
     if ($k['url'] != '' ) {
         echo '<a class="link flex p-2" target="' .$target . '" ' . $linkType. '="'  . $link . '" >'.$k['name'].'</a>';
@@ -52,7 +52,7 @@ foreach(@$this->menus as $menus => $k){
                 $link = '/' . $s['url'];
             }
 
-            echo '<li id="'.$s['item_id'].'" class="group transition ease-in duration-200 bg-primary hover:bg-accent rounded w-full pr-8"><a ' . $linkType. '="'  . $link . '"  target="' .$target . '" class="link flex p-2"   >' . $s['name'] . '</a> ';
+            echo '<li id="'.$s['item_id'].'" class="group transition ease-in duration-200 hover:bg-accent rounded w-full pr-8"><a ' . $linkType. '="'  . $link . '"  target="' .$target . '" class="link flex p-2"   >' . $s['name'] . '</a> ';
             // SUBLEVEL 2
             if ( @$menu_items[$s['item_id']] !== null ) {
                 echo '<span class="submenu-pointer grid items-center self-center justify-items-center rounded-full text-neutral-content absolute  right-1 top-3 w-4 h-4 text-xs"></span><ul class="w-full shadow-lg">';
@@ -64,7 +64,7 @@ foreach(@$this->menus as $menus => $k){
                         $link = '/' . $s2['url'];
                     }
 
-                    echo '<li id="'.$s2['item_id'].'" class="group transition ease-in duration-200 bg-primary hover:bg-accent rounded w-full pr-8"><a ' . $linkType. '="'  . $link . '"  target="' .$target . '" class="link flex p-2"   >' . $s2['name'] . '</a> ';
+                    echo '<li id="'.$s2['item_id'].'" class="group transition ease-in duration-200 hover:bg-accent rounded w-full pr-8"><a ' . $linkType. '="'  . $link . '"  target="' .$target . '" class="link flex p-2"   >' . $s2['name'] . '</a> ';
 
                     //SUBLEVEL 3
                     if ( @$menu_items[$s2['item_id']] !== null ) {
@@ -75,7 +75,7 @@ foreach(@$this->menus as $menus => $k){
                             } else {
                                 $link = '/' . $s3['url'];
                             }
-                            echo '<li id="'.$s3['item_id'].'" class="group transition ease-in duration-200 bg-primary hover:bg-accent rounded w-full pr-8"><a ' . $linkType. '="'  . $link . '"  target="' .$target . '" class="link flex p-2"   >' . $s3['name'] . '</a> ';
+                            echo '<li id="'.$s3['item_id'].'" class="group transition ease-in duration-200 hover:bg-accent rounded w-full pr-8"><a ' . $linkType. '="'  . $link . '"  target="' .$target . '" class="link flex p-2"   >' . $s3['name'] . '</a> ';
 
                             echo '</li>';
                         }

--- a/src/public/css/tailwind.output.css
+++ b/src/public/css/tailwind.output.css
@@ -673,6 +673,206 @@ html {
   --tab-radius: 0.4rem;
 }
 
+[data-theme=cyberpunk] {
+  color-scheme: light;
+  --b2: 87.8943% 0.16647 104.32;
+  --b3: 81.2786% 0.15394 104.32;
+  --in: 72.06% 0.191 231.6;
+  --su: 64.8% 0.150 160;
+  --wa: 84.71% 0.199 83.87;
+  --er: 71.76% 0.221 22.18;
+  --bc: 18.902% 0.0358 104.32;
+  --pc: 14.844% 0.0418 6.35;
+  --sc: 16.666% 0.0368 204.72;
+  --ac: 14.372% 0.04352 310.43;
+  --inc: 0% 0 0;
+  --suc: 0% 0 0;
+  --wac: 0% 0 0;
+  --erc: 0% 0 0;
+  --animation-btn: 0.25s;
+  --animation-input: .2s;
+  --btn-focus-scale: 0.95;
+  --border-btn: 1px;
+  --tab-border: 1px;
+  font-family: ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,Liberation Mono,Courier New,monospace;
+  --p: 74.22% 0.209 6.35;
+  --s: 83.33% 0.184 204.72;
+  --a: 71.86% 0.2176 310.43;
+  --n: 23.04% 0.065 269.31;
+  --nc: 94.51% 0.179 104.32;
+  --b1: 94.51% 0.179 104.32;
+  --rounded-box: 0;
+  --rounded-btn: 0;
+  --rounded-badge: 0;
+  --tab-radius: 0;
+}
+
+:root:has(input.theme-controller[value=cyberpunk]:checked) {
+  color-scheme: light;
+  --b2: 87.8943% 0.16647 104.32;
+  --b3: 81.2786% 0.15394 104.32;
+  --in: 72.06% 0.191 231.6;
+  --su: 64.8% 0.150 160;
+  --wa: 84.71% 0.199 83.87;
+  --er: 71.76% 0.221 22.18;
+  --bc: 18.902% 0.0358 104.32;
+  --pc: 14.844% 0.0418 6.35;
+  --sc: 16.666% 0.0368 204.72;
+  --ac: 14.372% 0.04352 310.43;
+  --inc: 0% 0 0;
+  --suc: 0% 0 0;
+  --wac: 0% 0 0;
+  --erc: 0% 0 0;
+  --animation-btn: 0.25s;
+  --animation-input: .2s;
+  --btn-focus-scale: 0.95;
+  --border-btn: 1px;
+  --tab-border: 1px;
+  font-family: ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,Liberation Mono,Courier New,monospace;
+  --p: 74.22% 0.209 6.35;
+  --s: 83.33% 0.184 204.72;
+  --a: 71.86% 0.2176 310.43;
+  --n: 23.04% 0.065 269.31;
+  --nc: 94.51% 0.179 104.32;
+  --b1: 94.51% 0.179 104.32;
+  --rounded-box: 0;
+  --rounded-btn: 0;
+  --rounded-badge: 0;
+  --tab-radius: 0;
+}
+
+[data-theme=valentine] {
+  color-scheme: light;
+  --b2: 88.0567% 0.024834 337.06289;
+  --b3: 81.4288% 0.022964 337.06289;
+  --pc: 13.7239% 0.030755 15.066527;
+  --sc: 14.3942% 0.029258 293.189609;
+  --ac: 14.2537% 0.014961 197.828857;
+  --inc: 90.923% 0.043042 262.880917;
+  --suc: 12.541% 0.033982 149.213788;
+  --wac: 13.3168% 0.031484 58.31834;
+  --erc: 14.614% 0.0414 27.33;
+  --rounded-box: 1rem;
+  --rounded-badge: 1.9rem;
+  --animation-btn: 0.25s;
+  --animation-input: .2s;
+  --btn-focus-scale: 0.95;
+  --border-btn: 1px;
+  --tab-border: 1px;
+  --p: 68.6197% 0.153774 15.066527;
+  --s: 71.971% 0.14629 293.189609;
+  --a: 71.2685% 0.074804 197.828857;
+  --n: 54.6053% 0.143342 358.004839;
+  --nc: 90.2701% 0.037202 336.955191;
+  --b1: 94.6846% 0.026703 337.06289;
+  --bc: 37.3085% 0.081131 4.606426;
+  --in: 54.615% 0.215208 262.880917;
+  --su: 62.7052% 0.169912 149.213788;
+  --wa: 66.584% 0.157422 58.31834;
+  --er: 73.07% 0.207 27.33;
+  --rounded-btn: 1.9rem;
+  --tab-radius: 0.7rem;
+}
+
+:root:has(input.theme-controller[value=valentine]:checked) {
+  color-scheme: light;
+  --b2: 88.0567% 0.024834 337.06289;
+  --b3: 81.4288% 0.022964 337.06289;
+  --pc: 13.7239% 0.030755 15.066527;
+  --sc: 14.3942% 0.029258 293.189609;
+  --ac: 14.2537% 0.014961 197.828857;
+  --inc: 90.923% 0.043042 262.880917;
+  --suc: 12.541% 0.033982 149.213788;
+  --wac: 13.3168% 0.031484 58.31834;
+  --erc: 14.614% 0.0414 27.33;
+  --rounded-box: 1rem;
+  --rounded-badge: 1.9rem;
+  --animation-btn: 0.25s;
+  --animation-input: .2s;
+  --btn-focus-scale: 0.95;
+  --border-btn: 1px;
+  --tab-border: 1px;
+  --p: 68.6197% 0.153774 15.066527;
+  --s: 71.971% 0.14629 293.189609;
+  --a: 71.2685% 0.074804 197.828857;
+  --n: 54.6053% 0.143342 358.004839;
+  --nc: 90.2701% 0.037202 336.955191;
+  --b1: 94.6846% 0.026703 337.06289;
+  --bc: 37.3085% 0.081131 4.606426;
+  --in: 54.615% 0.215208 262.880917;
+  --su: 62.7052% 0.169912 149.213788;
+  --wa: 66.584% 0.157422 58.31834;
+  --er: 73.07% 0.207 27.33;
+  --rounded-btn: 1.9rem;
+  --tab-radius: 0.7rem;
+}
+
+[data-theme=aqua] {
+  color-scheme: dark;
+  --b2: 45.3464% 0.118611 261.181672;
+  --b3: 41.9333% 0.109683 261.181672;
+  --bc: 89.7519% 0.025508 261.181672;
+  --sc: 12.1365% 0.02175 309.782946;
+  --ac: 18.6854% 0.020445 94.555431;
+  --nc: 12.2124% 0.023402 243.760661;
+  --inc: 90.923% 0.043042 262.880917;
+  --suc: 12.541% 0.033982 149.213788;
+  --wac: 13.3168% 0.031484 58.31834;
+  --erc: 14.79% 0.038 27.33;
+  --rounded-box: 1rem;
+  --rounded-btn: 0.5rem;
+  --rounded-badge: 1.9rem;
+  --animation-btn: 0.25s;
+  --animation-input: .2s;
+  --btn-focus-scale: 0.95;
+  --border-btn: 1px;
+  --tab-border: 1px;
+  --tab-radius: 0.5rem;
+  --p: 85.6617% 0.14498 198.6458;
+  --pc: 40.1249% 0.068266 197.603872;
+  --s: 60.6827% 0.108752 309.782946;
+  --a: 93.4269% 0.102225 94.555431;
+  --n: 61.0622% 0.117009 243.760661;
+  --b1: 48.7596% 0.127539 261.181672;
+  --in: 54.615% 0.215208 262.880917;
+  --su: 62.7052% 0.169912 149.213788;
+  --wa: 66.584% 0.157422 58.31834;
+  --er: 73.95% 0.19 27.33;
+}
+
+:root:has(input.theme-controller[value=aqua]:checked) {
+  color-scheme: dark;
+  --b2: 45.3464% 0.118611 261.181672;
+  --b3: 41.9333% 0.109683 261.181672;
+  --bc: 89.7519% 0.025508 261.181672;
+  --sc: 12.1365% 0.02175 309.782946;
+  --ac: 18.6854% 0.020445 94.555431;
+  --nc: 12.2124% 0.023402 243.760661;
+  --inc: 90.923% 0.043042 262.880917;
+  --suc: 12.541% 0.033982 149.213788;
+  --wac: 13.3168% 0.031484 58.31834;
+  --erc: 14.79% 0.038 27.33;
+  --rounded-box: 1rem;
+  --rounded-btn: 0.5rem;
+  --rounded-badge: 1.9rem;
+  --animation-btn: 0.25s;
+  --animation-input: .2s;
+  --btn-focus-scale: 0.95;
+  --border-btn: 1px;
+  --tab-border: 1px;
+  --tab-radius: 0.5rem;
+  --p: 85.6617% 0.14498 198.6458;
+  --pc: 40.1249% 0.068266 197.603872;
+  --s: 60.6827% 0.108752 309.782946;
+  --a: 93.4269% 0.102225 94.555431;
+  --n: 61.0622% 0.117009 243.760661;
+  --b1: 48.7596% 0.127539 261.181672;
+  --in: 54.615% 0.215208 262.880917;
+  --su: 62.7052% 0.169912 149.213788;
+  --wa: 66.584% 0.157422 58.31834;
+  --er: 73.95% 0.19 27.33;
+}
+
 *, ::before, ::after {
   --tw-border-spacing-x: 0;
   --tw-border-spacing-y: 0;
@@ -813,6 +1013,511 @@ html {
   .container {
     max-width: 1536px;
   }
+}
+
+.prose {
+  color: var(--tw-prose-body);
+  max-width: 65ch;
+}
+
+.prose :where(p):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  margin-top: 1.25em;
+  margin-bottom: 1.25em;
+}
+
+.prose :where([class~="lead"]):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  color: var(--tw-prose-lead);
+  font-size: 1.25em;
+  line-height: 1.6;
+  margin-top: 1.2em;
+  margin-bottom: 1.2em;
+}
+
+.prose :where(a):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  color: var(--tw-prose-links);
+  text-decoration: underline;
+  font-weight: 500;
+}
+
+.prose :where(strong):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  color: var(--tw-prose-bold);
+  font-weight: 600;
+}
+
+.prose :where(a strong):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  color: inherit;
+}
+
+.prose :where(blockquote strong):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  color: inherit;
+}
+
+.prose :where(thead th strong):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  color: inherit;
+}
+
+.prose :where(ol):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  list-style-type: decimal;
+  margin-top: 1.25em;
+  margin-bottom: 1.25em;
+  padding-inline-start: 1.625em;
+}
+
+.prose :where(ol[type="A"]):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  list-style-type: upper-alpha;
+}
+
+.prose :where(ol[type="a"]):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  list-style-type: lower-alpha;
+}
+
+.prose :where(ol[type="A" s]):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  list-style-type: upper-alpha;
+}
+
+.prose :where(ol[type="a" s]):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  list-style-type: lower-alpha;
+}
+
+.prose :where(ol[type="I"]):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  list-style-type: upper-roman;
+}
+
+.prose :where(ol[type="i"]):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  list-style-type: lower-roman;
+}
+
+.prose :where(ol[type="I" s]):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  list-style-type: upper-roman;
+}
+
+.prose :where(ol[type="i" s]):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  list-style-type: lower-roman;
+}
+
+.prose :where(ol[type="1"]):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  list-style-type: decimal;
+}
+
+.prose :where(ul):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  list-style-type: disc;
+  margin-top: 1.25em;
+  margin-bottom: 1.25em;
+  padding-inline-start: 1.625em;
+}
+
+.prose :where(ol > li):not(:where([class~="not-prose"],[class~="not-prose"] *))::marker {
+  font-weight: 400;
+  color: var(--tw-prose-counters);
+}
+
+.prose :where(ul > li):not(:where([class~="not-prose"],[class~="not-prose"] *))::marker {
+  color: var(--tw-prose-bullets);
+}
+
+.prose :where(dt):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  color: var(--tw-prose-headings);
+  font-weight: 600;
+  margin-top: 1.25em;
+}
+
+.prose :where(hr):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  border-color: var(--tw-prose-hr);
+  border-top-width: 1px;
+  margin-top: 3em;
+  margin-bottom: 3em;
+}
+
+.prose :where(blockquote):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  font-weight: 500;
+  font-style: italic;
+  color: var(--tw-prose-quotes);
+  border-inline-start-width: 0.25rem;
+  border-inline-start-color: var(--tw-prose-quote-borders);
+  quotes: "\201C""\201D""\2018""\2019";
+  margin-top: 1.6em;
+  margin-bottom: 1.6em;
+  padding-inline-start: 1em;
+}
+
+.prose :where(blockquote p:first-of-type):not(:where([class~="not-prose"],[class~="not-prose"] *))::before {
+  content: open-quote;
+}
+
+.prose :where(blockquote p:last-of-type):not(:where([class~="not-prose"],[class~="not-prose"] *))::after {
+  content: close-quote;
+}
+
+.prose :where(h1):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  color: var(--tw-prose-headings);
+  font-weight: 800;
+  font-size: 2.25em;
+  margin-top: 0;
+  margin-bottom: 0.8888889em;
+  line-height: 1.1111111;
+}
+
+.prose :where(h1 strong):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  font-weight: 900;
+  color: inherit;
+}
+
+.prose :where(h2):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  color: var(--tw-prose-headings);
+  font-weight: 700;
+  font-size: 1.5em;
+  margin-top: 2em;
+  margin-bottom: 1em;
+  line-height: 1.3333333;
+}
+
+.prose :where(h2 strong):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  font-weight: 800;
+  color: inherit;
+}
+
+.prose :where(h3):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  color: var(--tw-prose-headings);
+  font-weight: 600;
+  font-size: 1.25em;
+  margin-top: 1.6em;
+  margin-bottom: 0.6em;
+  line-height: 1.6;
+}
+
+.prose :where(h3 strong):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  font-weight: 700;
+  color: inherit;
+}
+
+.prose :where(h4):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  color: var(--tw-prose-headings);
+  font-weight: 600;
+  margin-top: 1.5em;
+  margin-bottom: 0.5em;
+  line-height: 1.5;
+}
+
+.prose :where(h4 strong):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  font-weight: 700;
+  color: inherit;
+}
+
+.prose :where(img):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  margin-top: 2em;
+  margin-bottom: 2em;
+}
+
+.prose :where(picture):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  display: block;
+  margin-top: 2em;
+  margin-bottom: 2em;
+}
+
+.prose :where(video):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  margin-top: 2em;
+  margin-bottom: 2em;
+}
+
+.prose :where(kbd):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  font-weight: 500;
+  font-family: inherit;
+  color: var(--tw-prose-kbd);
+  box-shadow: 0 0 0 1px rgb(var(--tw-prose-kbd-shadows) / 10%), 0 3px 0 rgb(var(--tw-prose-kbd-shadows) / 10%);
+  font-size: 0.875em;
+  border-radius: 0.3125rem;
+  padding-top: 0.1875em;
+  padding-inline-end: 0.375em;
+  padding-bottom: 0.1875em;
+  padding-inline-start: 0.375em;
+}
+
+.prose :where(code):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  color: var(--tw-prose-code);
+  font-weight: 600;
+  font-size: 0.875em;
+}
+
+.prose :where(code):not(:where([class~="not-prose"],[class~="not-prose"] *))::before {
+  content: "`";
+}
+
+.prose :where(code):not(:where([class~="not-prose"],[class~="not-prose"] *))::after {
+  content: "`";
+}
+
+.prose :where(a code):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  color: inherit;
+}
+
+.prose :where(h1 code):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  color: inherit;
+}
+
+.prose :where(h2 code):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  color: inherit;
+  font-size: 0.875em;
+}
+
+.prose :where(h3 code):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  color: inherit;
+  font-size: 0.9em;
+}
+
+.prose :where(h4 code):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  color: inherit;
+}
+
+.prose :where(blockquote code):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  color: inherit;
+}
+
+.prose :where(thead th code):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  color: inherit;
+}
+
+.prose :where(pre):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  color: var(--tw-prose-pre-code);
+  background-color: var(--tw-prose-pre-bg);
+  overflow-x: auto;
+  font-weight: 400;
+  font-size: 0.875em;
+  line-height: 1.7142857;
+  margin-top: 1.7142857em;
+  margin-bottom: 1.7142857em;
+  border-radius: 0.375rem;
+  padding-top: 0.8571429em;
+  padding-inline-end: 1.1428571em;
+  padding-bottom: 0.8571429em;
+  padding-inline-start: 1.1428571em;
+}
+
+.prose :where(pre code):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  background-color: transparent;
+  border-width: 0;
+  border-radius: 0;
+  padding: 0;
+  font-weight: inherit;
+  color: inherit;
+  font-size: inherit;
+  font-family: inherit;
+  line-height: inherit;
+}
+
+.prose :where(pre code):not(:where([class~="not-prose"],[class~="not-prose"] *))::before {
+  content: none;
+}
+
+.prose :where(pre code):not(:where([class~="not-prose"],[class~="not-prose"] *))::after {
+  content: none;
+}
+
+.prose :where(table):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  width: 100%;
+  table-layout: auto;
+  margin-top: 2em;
+  margin-bottom: 2em;
+  font-size: 0.875em;
+  line-height: 1.7142857;
+}
+
+.prose :where(thead):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  border-bottom-width: 1px;
+  border-bottom-color: var(--tw-prose-th-borders);
+}
+
+.prose :where(thead th):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  color: var(--tw-prose-headings);
+  font-weight: 600;
+  vertical-align: bottom;
+  padding-inline-end: 0.5714286em;
+  padding-bottom: 0.5714286em;
+  padding-inline-start: 0.5714286em;
+}
+
+.prose :where(tbody tr):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  border-bottom-width: 1px;
+  border-bottom-color: var(--tw-prose-td-borders);
+}
+
+.prose :where(tbody tr:last-child):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  border-bottom-width: 0;
+}
+
+.prose :where(tbody td):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  vertical-align: baseline;
+}
+
+.prose :where(tfoot):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  border-top-width: 1px;
+  border-top-color: var(--tw-prose-th-borders);
+}
+
+.prose :where(tfoot td):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  vertical-align: top;
+}
+
+.prose :where(th, td):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  text-align: start;
+}
+
+.prose :where(figure > *):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+.prose :where(figcaption):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  color: var(--tw-prose-captions);
+  font-size: 0.875em;
+  line-height: 1.4285714;
+  margin-top: 0.8571429em;
+}
+
+.prose {
+  --tw-prose-body: #374151;
+  --tw-prose-headings: #111827;
+  --tw-prose-lead: #4b5563;
+  --tw-prose-links: #111827;
+  --tw-prose-bold: #111827;
+  --tw-prose-counters: #6b7280;
+  --tw-prose-bullets: #d1d5db;
+  --tw-prose-hr: #e5e7eb;
+  --tw-prose-quotes: #111827;
+  --tw-prose-quote-borders: #e5e7eb;
+  --tw-prose-captions: #6b7280;
+  --tw-prose-kbd: #111827;
+  --tw-prose-kbd-shadows: 17 24 39;
+  --tw-prose-code: #111827;
+  --tw-prose-pre-code: #e5e7eb;
+  --tw-prose-pre-bg: #1f2937;
+  --tw-prose-th-borders: #d1d5db;
+  --tw-prose-td-borders: #e5e7eb;
+  --tw-prose-invert-body: #d1d5db;
+  --tw-prose-invert-headings: #fff;
+  --tw-prose-invert-lead: #9ca3af;
+  --tw-prose-invert-links: #fff;
+  --tw-prose-invert-bold: #fff;
+  --tw-prose-invert-counters: #9ca3af;
+  --tw-prose-invert-bullets: #4b5563;
+  --tw-prose-invert-hr: #374151;
+  --tw-prose-invert-quotes: #f3f4f6;
+  --tw-prose-invert-quote-borders: #374151;
+  --tw-prose-invert-captions: #9ca3af;
+  --tw-prose-invert-kbd: #fff;
+  --tw-prose-invert-kbd-shadows: 255 255 255;
+  --tw-prose-invert-code: #fff;
+  --tw-prose-invert-pre-code: #d1d5db;
+  --tw-prose-invert-pre-bg: rgb(0 0 0 / 50%);
+  --tw-prose-invert-th-borders: #4b5563;
+  --tw-prose-invert-td-borders: #374151;
+  font-size: 1rem;
+  line-height: 1.75;
+}
+
+.prose :where(picture > img):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+.prose :where(li):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  margin-top: 0.5em;
+  margin-bottom: 0.5em;
+}
+
+.prose :where(ol > li):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  padding-inline-start: 0.375em;
+}
+
+.prose :where(ul > li):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  padding-inline-start: 0.375em;
+}
+
+.prose :where(.prose > ul > li p):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  margin-top: 0.75em;
+  margin-bottom: 0.75em;
+}
+
+.prose :where(.prose > ul > li > p:first-child):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  margin-top: 1.25em;
+}
+
+.prose :where(.prose > ul > li > p:last-child):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  margin-bottom: 1.25em;
+}
+
+.prose :where(.prose > ol > li > p:first-child):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  margin-top: 1.25em;
+}
+
+.prose :where(.prose > ol > li > p:last-child):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  margin-bottom: 1.25em;
+}
+
+.prose :where(ul ul, ul ol, ol ul, ol ol):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  margin-top: 0.75em;
+  margin-bottom: 0.75em;
+}
+
+.prose :where(dl):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  margin-top: 1.25em;
+  margin-bottom: 1.25em;
+}
+
+.prose :where(dd):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  margin-top: 0.5em;
+  padding-inline-start: 1.625em;
+}
+
+.prose :where(hr + *):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  margin-top: 0;
+}
+
+.prose :where(h2 + *):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  margin-top: 0;
+}
+
+.prose :where(h3 + *):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  margin-top: 0;
+}
+
+.prose :where(h4 + *):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  margin-top: 0;
+}
+
+.prose :where(thead th:first-child):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  padding-inline-start: 0;
+}
+
+.prose :where(thead th:last-child):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  padding-inline-end: 0;
+}
+
+.prose :where(tbody td, tfoot td):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  padding-top: 0.5714286em;
+  padding-inline-end: 0.5714286em;
+  padding-bottom: 0.5714286em;
+  padding-inline-start: 0.5714286em;
+}
+
+.prose :where(tbody td:first-child, tfoot td:first-child):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  padding-inline-start: 0;
+}
+
+.prose :where(tbody td:last-child, tfoot td:last-child):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  padding-inline-end: 0;
+}
+
+.prose :where(figure):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  margin-top: 2em;
+  margin-bottom: 2em;
+}
+
+.prose :where(.prose > :first-child):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  margin-top: 0;
+}
+
+.prose :where(.prose > :last-child):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  margin-bottom: 0;
 }
 
 .alert {
@@ -1031,6 +1736,34 @@ html {
   color: var(--fallback-nc,oklch(var(--nc)/var(--tw-text-opacity)));
 }
 
+.carousel {
+  display: inline-flex;
+  overflow-x: scroll;
+  scroll-snap-type: x mandatory;
+  scroll-behavior: smooth;
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+}
+
+.carousel-item {
+  box-sizing: content-box;
+  display: flex;
+  flex: none;
+  scroll-snap-align: start;
+}
+
+.carousel-start .carousel-item {
+  scroll-snap-align: start;
+}
+
+.carousel-center .carousel-item {
+  scroll-snap-align: center;
+}
+
+.carousel-end .carousel-item {
+  scroll-snap-align: end;
+}
+
 .checkbox {
   flex-shrink: 0;
   --chkbg: var(--fallback-bc,oklch(var(--bc)/1));
@@ -1066,6 +1799,110 @@ html {
   --tw-content: '';
   content: var(--tw-content);
   background-color: var(--fallback-bc,oklch(var(--bc)/0.1));
+}
+
+.drawer {
+  position: relative;
+  display: grid;
+  grid-auto-columns: max-content auto;
+  width: 100%;
+}
+
+.drawer-content {
+  grid-column-start: 2;
+  grid-row-start: 1;
+  min-width: 0px;
+}
+
+.drawer-side {
+  pointer-events: none;
+  position: fixed;
+  inset-inline-start: 0px;
+  top: 0px;
+  grid-column-start: 1;
+  grid-row-start: 1;
+  display: grid;
+  width: 100%;
+  grid-template-columns: repeat(1, minmax(0, 1fr));
+  grid-template-rows: repeat(1, minmax(0, 1fr));
+  align-items: flex-start;
+  justify-items: start;
+  overflow-x: hidden;
+  overflow-y: hidden;
+  overscroll-behavior: contain;
+  height: 100vh;
+  height: 100dvh;
+}
+
+.drawer-side > .drawer-overlay {
+  position: sticky;
+  top: 0px;
+  place-self: stretch;
+  cursor: pointer;
+  background-color: transparent;
+  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-timing-function: cubic-bezier(0, 0, 0.2, 1);
+  transition-duration: 200ms;
+}
+
+.drawer-side > * {
+  grid-column-start: 1;
+  grid-row-start: 1;
+}
+
+.drawer-side > *:not(.drawer-overlay) {
+  transition-property: transform;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-timing-function: cubic-bezier(0, 0, 0.2, 1);
+  transition-duration: 300ms;
+  will-change: transform;
+  transform: translateX(-100%);
+}
+
+[dir="rtl"] .drawer-side > *:not(.drawer-overlay) {
+  transform: translateX(100%);
+}
+
+.drawer-toggle {
+  position: fixed;
+  height: 0px;
+  width: 0px;
+  -webkit-appearance: none;
+     -moz-appearance: none;
+          appearance: none;
+  opacity: 0;
+}
+
+.drawer-toggle:checked ~ .drawer-side {
+  pointer-events: auto;
+  visibility: visible;
+  overflow-y: auto;
+}
+
+.drawer-toggle:checked ~ .drawer-side > *:not(.drawer-overlay) {
+  transform: translateX(0%);
+}
+
+.drawer-end .drawer-toggle ~ .drawer-content {
+  grid-column-start: 1;
+}
+
+.drawer-end .drawer-toggle ~ .drawer-side {
+  grid-column-start: 2;
+  justify-items: end;
+}
+
+.drawer-end .drawer-toggle ~ .drawer-side > *:not(.drawer-overlay) {
+  transform: translateX(100%);
+}
+
+[dir="rtl"] .drawer-end .drawer-toggle ~ .drawer-side > *:not(.drawer-overlay) {
+  transform: translateX(-100%);
+}
+
+.drawer-end .drawer-toggle:checked ~ .drawer-side > *:not(.drawer-overlay) {
+  transform: translateX(0%);
 }
 
 .dropdown {
@@ -1204,6 +2041,15 @@ html {
     }
   }
 
+  .btn-outline:hover {
+    --tw-border-opacity: 1;
+    border-color: var(--fallback-bc,oklch(var(--bc)/var(--tw-border-opacity)));
+    --tw-bg-opacity: 1;
+    background-color: var(--fallback-bc,oklch(var(--bc)/var(--tw-bg-opacity)));
+    --tw-text-opacity: 1;
+    color: var(--fallback-b1,oklch(var(--b1)/var(--tw-text-opacity)));
+  }
+
   .btn-outline.btn-primary:hover {
     --tw-text-opacity: 1;
     color: var(--fallback-pc,oklch(var(--pc)/var(--tw-text-opacity)));
@@ -1225,6 +2071,54 @@ html {
     .btn-outline.btn-secondary:hover {
       background-color: color-mix(in oklab, var(--fallback-s,oklch(var(--s)/1)) 90%, black);
       border-color: color-mix(in oklab, var(--fallback-s,oklch(var(--s)/1)) 90%, black);
+    }
+  }
+
+  .btn-outline.btn-accent:hover {
+    --tw-text-opacity: 1;
+    color: var(--fallback-ac,oklch(var(--ac)/var(--tw-text-opacity)));
+  }
+
+  @supports (color: color-mix(in oklab, black, black)) {
+    .btn-outline.btn-accent:hover {
+      background-color: color-mix(in oklab, var(--fallback-a,oklch(var(--a)/1)) 90%, black);
+      border-color: color-mix(in oklab, var(--fallback-a,oklch(var(--a)/1)) 90%, black);
+    }
+  }
+
+  .btn-outline.btn-success:hover {
+    --tw-text-opacity: 1;
+    color: var(--fallback-suc,oklch(var(--suc)/var(--tw-text-opacity)));
+  }
+
+  @supports (color: color-mix(in oklab, black, black)) {
+    .btn-outline.btn-success:hover {
+      background-color: color-mix(in oklab, var(--fallback-su,oklch(var(--su)/1)) 90%, black);
+      border-color: color-mix(in oklab, var(--fallback-su,oklch(var(--su)/1)) 90%, black);
+    }
+  }
+
+  .btn-outline.btn-info:hover {
+    --tw-text-opacity: 1;
+    color: var(--fallback-inc,oklch(var(--inc)/var(--tw-text-opacity)));
+  }
+
+  @supports (color: color-mix(in oklab, black, black)) {
+    .btn-outline.btn-info:hover {
+      background-color: color-mix(in oklab, var(--fallback-in,oklch(var(--in)/1)) 90%, black);
+      border-color: color-mix(in oklab, var(--fallback-in,oklch(var(--in)/1)) 90%, black);
+    }
+  }
+
+  .btn-outline.btn-warning:hover {
+    --tw-text-opacity: 1;
+    color: var(--fallback-wac,oklch(var(--wac)/var(--tw-text-opacity)));
+  }
+
+  @supports (color: color-mix(in oklab, black, black)) {
+    .btn-outline.btn-warning:hover {
+      background-color: color-mix(in oklab, var(--fallback-wa,oklch(var(--wa)/1)) 90%, black);
+      border-color: color-mix(in oklab, var(--fallback-wa,oklch(var(--wa)/1)) 90%, black);
     }
   }
 
@@ -1624,6 +2518,33 @@ html {
   align-items: center;
 }
 
+.modal-box {
+  max-height: calc(100vh - 5em);
+  grid-column-start: 1;
+  grid-row-start: 1;
+  width: 91.666667%;
+  max-width: 32rem;
+  --tw-scale-x: .9;
+  --tw-scale-y: .9;
+  transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
+  border-bottom-right-radius: var(--rounded-box, 1rem);
+  border-bottom-left-radius: var(--rounded-box, 1rem);
+  border-top-left-radius: var(--rounded-box, 1rem);
+  border-top-right-radius: var(--rounded-box, 1rem);
+  --tw-bg-opacity: 1;
+  background-color: var(--fallback-b1,oklch(var(--b1)/var(--tw-bg-opacity)));
+  padding: 1.5rem;
+  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, -webkit-backdrop-filter;
+  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter;
+  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter, -webkit-backdrop-filter;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-timing-function: cubic-bezier(0, 0, 0.2, 1);
+  transition-duration: 200ms;
+  box-shadow: rgba(0, 0, 0, 0.25) 0px 25px 50px -12px;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+}
+
 .modal-open,
 .modal:target,
 .modal-toggle:checked + .modal,
@@ -1631,6 +2552,12 @@ html {
   pointer-events: auto;
   visibility: visible;
   opacity: 1;
+}
+
+.modal-action {
+  display: flex;
+  margin-top: 1.5rem;
+  justify-content: flex-end;
 }
 
 :root:has(:is(.modal-open, .modal:target, .modal-toggle:checked + .modal, .modal[open])) {
@@ -2018,6 +2945,10 @@ input.tab:checked + .tab-content,
   .btn-error {
     --btn-color: var(--fallback-er);
   }
+
+  .prose :where(code):not(:where([class~="not-prose"] *, pre *)) {
+    background-color: var(--fallback-b3,oklch(var(--b3)/1));
+  }
 }
 
 @supports (color: color-mix(in oklab, black, black)) {
@@ -2029,6 +2960,26 @@ input.tab:checked + .tab-content,
   .btn-outline.btn-secondary.btn-active {
     background-color: color-mix(in oklab, var(--fallback-s,oklch(var(--s)/1)) 90%, black);
     border-color: color-mix(in oklab, var(--fallback-s,oklch(var(--s)/1)) 90%, black);
+  }
+
+  .btn-outline.btn-accent.btn-active {
+    background-color: color-mix(in oklab, var(--fallback-a,oklch(var(--a)/1)) 90%, black);
+    border-color: color-mix(in oklab, var(--fallback-a,oklch(var(--a)/1)) 90%, black);
+  }
+
+  .btn-outline.btn-success.btn-active {
+    background-color: color-mix(in oklab, var(--fallback-su,oklch(var(--su)/1)) 90%, black);
+    border-color: color-mix(in oklab, var(--fallback-su,oklch(var(--su)/1)) 90%, black);
+  }
+
+  .btn-outline.btn-info.btn-active {
+    background-color: color-mix(in oklab, var(--fallback-in,oklch(var(--in)/1)) 90%, black);
+    border-color: color-mix(in oklab, var(--fallback-in,oklch(var(--in)/1)) 90%, black);
+  }
+
+  .btn-outline.btn-warning.btn-active {
+    background-color: color-mix(in oklab, var(--fallback-wa,oklch(var(--wa)/1)) 90%, black);
+    border-color: color-mix(in oklab, var(--fallback-wa,oklch(var(--wa)/1)) 90%, black);
   }
 
   .btn-outline.btn-error.btn-active {
@@ -2103,6 +3054,25 @@ input.tab:checked + .tab-content,
   background-color: var(--fallback-bc,oklch(var(--bc)/0.2));
 }
 
+.btn-outline {
+  border-color: currentColor;
+  background-color: transparent;
+  --tw-text-opacity: 1;
+  color: var(--fallback-bc,oklch(var(--bc)/var(--tw-text-opacity)));
+  --tw-shadow: 0 0 #0000;
+  --tw-shadow-colored: 0 0 #0000;
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.btn-outline.btn-active {
+  --tw-border-opacity: 1;
+  border-color: var(--fallback-bc,oklch(var(--bc)/var(--tw-border-opacity)));
+  --tw-bg-opacity: 1;
+  background-color: var(--fallback-bc,oklch(var(--bc)/var(--tw-bg-opacity)));
+  --tw-text-opacity: 1;
+  color: var(--fallback-b1,oklch(var(--b1)/var(--tw-text-opacity)));
+}
+
 .btn-outline.btn-primary {
   --tw-text-opacity: 1;
   color: var(--fallback-p,oklch(var(--p)/var(--tw-text-opacity)));
@@ -2121,6 +3091,46 @@ input.tab:checked + .tab-content,
 .btn-outline.btn-secondary.btn-active {
   --tw-text-opacity: 1;
   color: var(--fallback-sc,oklch(var(--sc)/var(--tw-text-opacity)));
+}
+
+.btn-outline.btn-accent {
+  --tw-text-opacity: 1;
+  color: var(--fallback-a,oklch(var(--a)/var(--tw-text-opacity)));
+}
+
+.btn-outline.btn-accent.btn-active {
+  --tw-text-opacity: 1;
+  color: var(--fallback-ac,oklch(var(--ac)/var(--tw-text-opacity)));
+}
+
+.btn-outline.btn-success {
+  --tw-text-opacity: 1;
+  color: var(--fallback-su,oklch(var(--su)/var(--tw-text-opacity)));
+}
+
+.btn-outline.btn-success.btn-active {
+  --tw-text-opacity: 1;
+  color: var(--fallback-suc,oklch(var(--suc)/var(--tw-text-opacity)));
+}
+
+.btn-outline.btn-info {
+  --tw-text-opacity: 1;
+  color: var(--fallback-in,oklch(var(--in)/var(--tw-text-opacity)));
+}
+
+.btn-outline.btn-info.btn-active {
+  --tw-text-opacity: 1;
+  color: var(--fallback-inc,oklch(var(--inc)/var(--tw-text-opacity)));
+}
+
+.btn-outline.btn-warning {
+  --tw-text-opacity: 1;
+  color: var(--fallback-wa,oklch(var(--wa)/var(--tw-text-opacity)));
+}
+
+.btn-outline.btn-warning.btn-active {
+  --tw-text-opacity: 1;
+  color: var(--fallback-wac,oklch(var(--wac)/var(--tw-text-opacity)));
 }
 
 .btn-outline.btn-error {
@@ -2209,6 +3219,10 @@ input.tab:checked + .tab-content,
   border-radius: inherit;
 }
 
+.carousel::-webkit-scrollbar {
+  display: none;
+}
+
 .checkbox:focus {
   box-shadow: none;
 }
@@ -2272,6 +3286,16 @@ input.tab:checked + .tab-content,
 
 .divider:not(:empty) {
   gap: 1rem;
+}
+
+.drawer-toggle:checked ~ .drawer-side > .drawer-overlay {
+  background-color: #0006;
+}
+
+.drawer-toggle:focus-visible ~ .drawer-content label.drawer-button {
+  outline-style: solid;
+  outline-width: 2px;
+  outline-offset: 2px;
 }
 
 .dropdown.dropdown-open .dropdown-content,
@@ -2595,6 +3619,12 @@ input.tab:checked + .tab-content,
   --tw-scale-x: 1;
   --tw-scale-y: 1;
   transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
+}
+
+.modal-action > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(0.5rem * var(--tw-space-x-reverse));
+  margin-left: calc(0.5rem * calc(1 - var(--tw-space-x-reverse)));
 }
 
 @keyframes modal-pop {
@@ -3094,6 +4124,45 @@ input.tab:checked + .tab-content,
       var(--handleoffsetcalculator) 0 0 3px var(--fallback-bc,oklch(var(--bc)/1)) inset;
 }
 
+:root .prose {
+  --tw-prose-body: var(--fallback-bc,oklch(var(--bc)/0.8));
+  --tw-prose-headings: var(--fallback-bc,oklch(var(--bc)/1));
+  --tw-prose-lead: var(--fallback-bc,oklch(var(--bc)/1));
+  --tw-prose-links: var(--fallback-bc,oklch(var(--bc)/1));
+  --tw-prose-bold: var(--fallback-bc,oklch(var(--bc)/1));
+  --tw-prose-counters: var(--fallback-bc,oklch(var(--bc)/1));
+  --tw-prose-bullets: var(--fallback-bc,oklch(var(--bc)/0.5));
+  --tw-prose-hr: var(--fallback-bc,oklch(var(--bc)/0.2));
+  --tw-prose-quotes: var(--fallback-bc,oklch(var(--bc)/1));
+  --tw-prose-quote-borders: var(--fallback-bc,oklch(var(--bc)/0.2));
+  --tw-prose-captions: var(--fallback-bc,oklch(var(--bc)/0.5));
+  --tw-prose-code: var(--fallback-bc,oklch(var(--bc)/1));
+  --tw-prose-pre-code: var(--fallback-nc,oklch(var(--nc)/1));
+  --tw-prose-pre-bg: var(--fallback-n,oklch(var(--n)/1));
+  --tw-prose-th-borders: var(--fallback-bc,oklch(var(--bc)/0.5));
+  --tw-prose-td-borders: var(--fallback-bc,oklch(var(--bc)/0.2));
+}
+
+.prose :where(code):not(:where([class~="not-prose"] *, pre *)) {
+  padding: 1px 8px;
+  border-radius: var(--rounded-badge);
+  font-weight: initial;
+  background-color: var(--fallback-bc,oklch(var(--bc)/0.1));
+}
+
+.prose :where(code):not(:where([class~="not-prose"], [class~="not-prose"] *))::before, .prose :where(code):not(:where([class~="not-prose"], [class~="not-prose"] *))::after {
+  display: none;
+}
+
+.prose pre code {
+  border-radius: 0;
+  padding: 0;
+}
+
+.prose :where(tbody tr, thead):not(:where([class~="not-prose"] *)) {
+  border-bottom-color: var(--fallback-bc,oklch(var(--bc)/0.2));
+}
+
 .artboard.phone {
   width: 320px;
 }
@@ -3213,6 +4282,41 @@ input.tab:checked + .tab-content,
 [type="checkbox"].checkbox-sm {
   height: 1.25rem;
   width: 1.25rem;
+}
+
+.drawer-open > .drawer-toggle {
+  display: none;
+}
+
+.drawer-open > .drawer-toggle ~ .drawer-side {
+  pointer-events: auto;
+  visibility: visible;
+  position: sticky;
+  display: block;
+  width: auto;
+  overscroll-behavior: auto;
+}
+
+.drawer-open > .drawer-toggle ~ .drawer-side > *:not(.drawer-overlay) {
+  transform: translateX(0%);
+}
+
+[dir="rtl"] .drawer-open > .drawer-toggle ~ .drawer-side > *:not(.drawer-overlay) {
+  transform: translateX(0%);
+}
+
+.drawer-open > .drawer-toggle:checked ~ .drawer-side {
+  pointer-events: auto;
+  visibility: visible;
+}
+
+.drawer-open > .drawer-side {
+  overflow-y: auto;
+}
+
+html:has(.drawer-toggle:checked) {
+  overflow-y: hidden;
+  scrollbar-gutter: stable;
 }
 
 .input-sm {
@@ -3366,6 +4470,11 @@ input.tab:checked + .tab-content,
   right: 7%;
 }
 
+.drawer-open > .drawer-toggle ~ .drawer-side > .drawer-overlay {
+  cursor: default;
+  background-color: transparent;
+}
+
 .join.join-vertical > :where(*:not(:first-child)) {
   margin-left: 0px;
   margin-right: 0px;
@@ -3393,6 +4502,45 @@ input.tab:checked + .tab-content,
   padding-right: 0.75rem;
   padding-top: 0.5rem;
   padding-bottom: 0.5rem;
+}
+
+.modal-top :where(.modal-box) {
+  width: 100%;
+  max-width: none;
+  --tw-translate-y: -2.5rem;
+  --tw-scale-x: 1;
+  --tw-scale-y: 1;
+  transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
+  border-bottom-right-radius: var(--rounded-box, 1rem);
+  border-bottom-left-radius: var(--rounded-box, 1rem);
+  border-top-left-radius: 0px;
+  border-top-right-radius: 0px;
+}
+
+.modal-middle :where(.modal-box) {
+  width: 91.666667%;
+  max-width: 32rem;
+  --tw-translate-y: 0px;
+  --tw-scale-x: .9;
+  --tw-scale-y: .9;
+  transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
+  border-top-left-radius: var(--rounded-box, 1rem);
+  border-top-right-radius: var(--rounded-box, 1rem);
+  border-bottom-right-radius: var(--rounded-box, 1rem);
+  border-bottom-left-radius: var(--rounded-box, 1rem);
+}
+
+.modal-bottom :where(.modal-box) {
+  width: 100%;
+  max-width: none;
+  --tw-translate-y: 2.5rem;
+  --tw-scale-x: 1;
+  --tw-scale-y: 1;
+  transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
+  border-top-left-radius: var(--rounded-box, 1rem);
+  border-top-right-radius: var(--rounded-box, 1rem);
+  border-bottom-right-radius: 0px;
+  border-bottom-left-radius: 0px;
 }
 
 .table-xs :not(thead):not(tfoot) tr {
@@ -3518,6 +4666,10 @@ input.tab:checked + .tab-content,
   position: relative;
 }
 
+.sticky {
+  position: sticky;
+}
+
 .inset-0 {
   inset: 0px;
 }
@@ -3534,6 +4686,10 @@ input.tab:checked + .tab-content,
   left: 0px;
 }
 
+.left-5 {
+  left: 1.25rem;
+}
+
 .left-72 {
   left: 18rem;
 }
@@ -3546,12 +4702,20 @@ input.tab:checked + .tab-content,
   right: 0.25rem;
 }
 
+.right-5 {
+  right: 1.25rem;
+}
+
 .top-0 {
   top: 0px;
 }
 
 .top-1 {
   top: 0.25rem;
+}
+
+.top-1\/2 {
+  top: 50%;
 }
 
 .top-12 {
@@ -3570,24 +4734,20 @@ input.tab:checked + .tab-content,
   z-index: 1;
 }
 
-.z-\[99999\] {
-  z-index: 99999;
-}
-
-.z-\[99\] {
-  z-index: 99;
-}
-
-.z-\[999999\] {
-  z-index: 999999;
+.z-\[999997\] {
+  z-index: 999997;
 }
 
 .z-\[999998\] {
   z-index: 999998;
 }
 
-.z-\[999997\] {
-  z-index: 999997;
+.z-\[99999\] {
+  z-index: 99999;
+}
+
+.z-\[99\] {
+  z-index: 99;
 }
 
 .col-span-1 {
@@ -3634,6 +4794,10 @@ input.tab:checked + .tab-content,
   margin: 0px;
 }
 
+.m-1 {
+  margin: 0.25rem;
+}
+
 .mx-2 {
   margin-left: 0.5rem;
   margin-right: 0.5rem;
@@ -3673,6 +4837,10 @@ input.tab:checked + .tab-content,
 
 .mb-5 {
   margin-bottom: 1.25rem;
+}
+
+.mb-72 {
+  margin-bottom: 18rem;
 }
 
 .mt-1 {
@@ -3842,6 +5010,10 @@ input.tab:checked + .tab-content,
   min-height: 100dvh;
 }
 
+.min-h-full {
+  min-height: 100%;
+}
+
 .min-h-screen {
   min-height: 100vh;
 }
@@ -3870,6 +5042,10 @@ input.tab:checked + .tab-content,
   width: 1rem;
 }
 
+.w-40 {
+  width: 10rem;
+}
+
 .w-5 {
   width: 1.25rem;
 }
@@ -3888,6 +5064,10 @@ input.tab:checked + .tab-content,
 
 .w-8 {
   width: 2rem;
+}
+
+.w-80 {
+  width: 20rem;
 }
 
 .w-full {
@@ -3929,6 +5109,11 @@ input.tab:checked + .tab-content,
 
 .shrink-0 {
   flex-shrink: 0;
+}
+
+.-translate-y-1\/2 {
+  --tw-translate-y: -50%;
+  transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
 }
 
 .rotate-180 {
@@ -4004,6 +5189,10 @@ input.tab:checked + .tab-content,
 
 .justify-start {
   justify-content: flex-start;
+}
+
+.justify-center {
+  justify-content: center;
 }
 
 .justify-between {
@@ -4155,6 +5344,11 @@ input.tab:checked + .tab-content,
   background-color: var(--fallback-b1,oklch(var(--b1)/var(--tw-bg-opacity)));
 }
 
+.bg-base-200 {
+  --tw-bg-opacity: 1;
+  background-color: var(--fallback-b2,oklch(var(--b2)/var(--tw-bg-opacity)));
+}
+
 .bg-base-300 {
   --tw-bg-opacity: 1;
   background-color: var(--fallback-b3,oklch(var(--b3)/var(--tw-bg-opacity)));
@@ -4205,11 +5399,6 @@ input.tab:checked + .tab-content,
   background-color: var(--fallback-p,oklch(var(--p)/var(--tw-bg-opacity)));
 }
 
-.bg-red-200 {
-  --tw-bg-opacity: 1;
-  background-color: rgb(254 202 202 / var(--tw-bg-opacity));
-}
-
 .bg-red-400 {
   --tw-bg-opacity: 1;
   background-color: rgb(248 113 113 / var(--tw-bg-opacity));
@@ -4233,6 +5422,11 @@ input.tab:checked + .tab-content,
 .bg-yellow-100 {
   --tw-bg-opacity: 1;
   background-color: rgb(254 249 195 / var(--tw-bg-opacity));
+}
+
+.bg-primary-content {
+  --tw-bg-opacity: 1;
+  background-color: var(--fallback-pc,oklch(var(--pc)/var(--tw-bg-opacity)));
 }
 
 .bg-opacity-60 {
@@ -4389,6 +5583,16 @@ input.tab:checked + .tab-content,
   color: var(--fallback-ac,oklch(var(--ac)/var(--tw-text-opacity)));
 }
 
+.text-base-content {
+  --tw-text-opacity: 1;
+  color: var(--fallback-bc,oklch(var(--bc)/var(--tw-text-opacity)));
+}
+
+.text-green-600 {
+  --tw-text-opacity: 1;
+  color: rgb(22 163 74 / var(--tw-text-opacity));
+}
+
 .text-neutral-content {
   --tw-text-opacity: 1;
   color: var(--fallback-nc,oklch(var(--nc)/var(--tw-text-opacity)));
@@ -4409,16 +5613,17 @@ input.tab:checked + .tab-content,
   color: rgb(255 255 255 / var(--tw-text-opacity));
 }
 
+.text-neutral {
+  --tw-text-opacity: 1;
+  color: var(--fallback-n,oklch(var(--n)/var(--tw-text-opacity)));
+}
+
 .underline {
   text-decoration-line: underline;
 }
 
 .opacity-60 {
   opacity: 0.6;
-}
-
-.opacity-\[30\%\] {
-  opacity: 30%;
 }
 
 .shadow {
@@ -4461,12 +5666,6 @@ input.tab:checked + .tab-content,
 
 .backdrop-blur-lg {
   --tw-backdrop-blur: blur(16px);
-  -webkit-backdrop-filter: var(--tw-backdrop-blur) var(--tw-backdrop-brightness) var(--tw-backdrop-contrast) var(--tw-backdrop-grayscale) var(--tw-backdrop-hue-rotate) var(--tw-backdrop-invert) var(--tw-backdrop-opacity) var(--tw-backdrop-saturate) var(--tw-backdrop-sepia);
-          backdrop-filter: var(--tw-backdrop-blur) var(--tw-backdrop-brightness) var(--tw-backdrop-contrast) var(--tw-backdrop-grayscale) var(--tw-backdrop-hue-rotate) var(--tw-backdrop-invert) var(--tw-backdrop-opacity) var(--tw-backdrop-saturate) var(--tw-backdrop-sepia);
-}
-
-.backdrop-blur-md {
-  --tw-backdrop-blur: blur(12px);
   -webkit-backdrop-filter: var(--tw-backdrop-blur) var(--tw-backdrop-brightness) var(--tw-backdrop-contrast) var(--tw-backdrop-grayscale) var(--tw-backdrop-hue-rotate) var(--tw-backdrop-invert) var(--tw-backdrop-opacity) var(--tw-backdrop-saturate) var(--tw-backdrop-sepia);
           backdrop-filter: var(--tw-backdrop-blur) var(--tw-backdrop-brightness) var(--tw-backdrop-contrast) var(--tw-backdrop-grayscale) var(--tw-backdrop-hue-rotate) var(--tw-backdrop-invert) var(--tw-backdrop-opacity) var(--tw-backdrop-saturate) var(--tw-backdrop-sepia);
 }
@@ -5374,6 +6573,12 @@ input.tab:checked + .tab-content,
   color: var(--fallback-a,oklch(var(--a)/var(--tw-text-opacity))) !important;
 }
 
+/* Typography */
+
+.prose {
+  max-width: 100%;
+}
+
 @media (min-width: 768px) {
   @media (hover:hover) {
     .md\:table tr.hover:hover,.md\:table tr.hover:nth-child(even):hover {
@@ -5600,6 +6805,10 @@ input.tab:checked + .tab-content,
 
   .md\:rounded-box {
     border-radius: var(--rounded-box, 1rem);
+  }
+
+  .md\:rounded-lg {
+    border-radius: 0.5rem;
   }
 
   .md\:p-8 {

--- a/src/public/css/tailwind.output.css
+++ b/src/public/css/tailwind.output.css
@@ -4823,6 +4823,10 @@ html:has(.drawer-toggle:checked) {
   margin-bottom: auto;
 }
 
+.mb-1 {
+  margin-bottom: 0.25rem;
+}
+
 .mb-10 {
   margin-bottom: 2.5rem;
 }
@@ -4841,6 +4845,10 @@ html:has(.drawer-toggle:checked) {
 
 .mb-72 {
   margin-bottom: 18rem;
+}
+
+.mr-1 {
+  margin-right: 0.25rem;
 }
 
 .mt-1 {
@@ -4950,12 +4958,12 @@ html:has(.drawer-toggle:checked) {
   height: 1.5rem;
 }
 
-.h-64 {
-  height: 16rem;
-}
-
 .h-8 {
   height: 2rem;
+}
+
+.h-96 {
+  height: 24rem;
 }
 
 .h-auto {
@@ -5399,6 +5407,11 @@ html:has(.drawer-toggle:checked) {
   background-color: var(--fallback-p,oklch(var(--p)/var(--tw-bg-opacity)));
 }
 
+.bg-primary-content {
+  --tw-bg-opacity: 1;
+  background-color: var(--fallback-pc,oklch(var(--pc)/var(--tw-bg-opacity)));
+}
+
 .bg-red-400 {
   --tw-bg-opacity: 1;
   background-color: rgb(248 113 113 / var(--tw-bg-opacity));
@@ -5422,11 +5435,6 @@ html:has(.drawer-toggle:checked) {
 .bg-yellow-100 {
   --tw-bg-opacity: 1;
   background-color: rgb(254 249 195 / var(--tw-bg-opacity));
-}
-
-.bg-primary-content {
-  --tw-bg-opacity: 1;
-  background-color: var(--fallback-pc,oklch(var(--pc)/var(--tw-bg-opacity)));
 }
 
 .bg-opacity-60 {
@@ -5593,6 +5601,11 @@ html:has(.drawer-toggle:checked) {
   color: rgb(22 163 74 / var(--tw-text-opacity));
 }
 
+.text-neutral {
+  --tw-text-opacity: 1;
+  color: var(--fallback-n,oklch(var(--n)/var(--tw-text-opacity)));
+}
+
 .text-neutral-content {
   --tw-text-opacity: 1;
   color: var(--fallback-nc,oklch(var(--nc)/var(--tw-text-opacity)));
@@ -5611,11 +5624,6 @@ html:has(.drawer-toggle:checked) {
 .text-white {
   --tw-text-opacity: 1;
   color: rgb(255 255 255 / var(--tw-text-opacity));
-}
-
-.text-neutral {
-  --tw-text-opacity: 1;
-  color: var(--fallback-n,oklch(var(--n)/var(--tw-text-opacity)));
 }
 
 .underline {
@@ -6194,15 +6202,6 @@ html:has(.drawer-toggle:checked) {
   box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow) !important;
 }
 
-/* tinyMCE should be below the header */
-
-#mce_fullscreen_container {
-  top: 4rem !important;
-  height: 100dvh !important;
-  overflow: auto !important;
-  padding-bottom: 4rem !important;
-}
-
 /* with selecting the specific div inside template or page, user should be able to insert a new object directly into it */
 
 #droppable * {
@@ -6507,9 +6506,15 @@ html:has(.drawer-toggle:checked) {
   display: none;
 }
 
-.cssjswrapp.fs, .cssjswrapp2.fs {
+/* fullscreen elements adjust */
+
+.cssjswrapp.fs, .cssjswrapp2.fs, #selected-object-html-wrapper.fs {
   overflow-y: auto !important;
   padding: 1rem !important;
+}
+
+#selected-object-html-wrapper.fs textarea {
+  height: 100dvh;
 }
 
 /* override ui-autocomplete */

--- a/src/tailwind.config.js
+++ b/src/tailwind.config.js
@@ -1,12 +1,12 @@
 /** @type {import('tailwindcss').Config} */
 export default {
-  content: ["./legacy/dev-application/**/*.{php,phtml,js}"],
+  content: ["./legacy/dev-application/**/*.{php,phtml,js}", "./public/cache/*"],
   theme: {
     extend: {},
   },
-  plugins: [require("daisyui")],
+  plugins: [require("@tailwindcss/typography"), require("daisyui")],
   daisyui: {
-    themes: ["nord", "retro"],
+    themes: ["nord", "retro", 'cyberpunk', 'valentine', 'aqua'],
   },
 }
 

--- a/src/tailwind.input.css
+++ b/src/tailwind.input.css
@@ -104,3 +104,8 @@
   @apply relative px-2 rounded;
   @apply hover:text-accent !important;
 }
+
+/* Typography */
+.prose {
+  max-width: 100%;
+}

--- a/src/tailwind.input.css
+++ b/src/tailwind.input.css
@@ -50,11 +50,6 @@
   @apply shadow-lg bg-neutral-content !important;
 }
 
-/* tinyMCE should be below the header */
-#mce_fullscreen_container {
-  @apply top-16 h-dvh overflow-auto pb-16 !important;
-}
-
 /* with selecting the specific div inside template or page, user should be able to insert a new object directly into it */
 #droppable * {
   @apply border border-dashed border-transparent !important;
@@ -79,9 +74,12 @@
 #what-label, #submitSearch-label {
   @apply hidden;
 }
-
-.cssjswrapp.fs, .cssjswrapp2.fs {
+/* fullscreen elements adjust */
+.cssjswrapp.fs, .cssjswrapp2.fs, #selected-object-html-wrapper.fs {
   @apply overflow-y-auto p-4 !important;
+}
+#selected-object-html-wrapper.fs textarea {
+  @apply h-dvh;
 }
 /* override ui-autocomplete */
 .ui-autocomplete {


### PR DESCRIPTION
Since TinyMCE is removed, we need some functionality for editing text like in other WYSIWYG editors. Buttons for making the selected text bold, italic, underlined, and the whole text in object centered, left or right aligned are added. Also editing of object's HTML is added and an option to do it in fullscreen, since the area in Properties panel is too small to be used all the time.