### PR TITLE
Fix ace-editor cursor misplacement

### DIFF
--- a/src/public/css/tailwind.output.css
+++ b/src/public/css/tailwind.output.css
@@ -3221,42 +3221,6 @@ input.tab:checked + .tab-content,
   margin-top: 0;
 }
 
-.mockup-phone .camera {
-  position: relative;
-  top: 0px;
-  left: 0px;
-  background: #000;
-  height: 25px;
-  width: 150px;
-  margin: 0 auto;
-  border-bottom-left-radius: 17px;
-  border-bottom-right-radius: 17px;
-  z-index: 11;
-}
-
-.mockup-phone .camera:before {
-  content: "";
-  position: absolute;
-  top: 35%;
-  left: 50%;
-  width: 50px;
-  height: 4px;
-  border-radius: 5px;
-  background-color: #0c0b0e;
-  transform: translate(-50%, -50%);
-}
-
-.mockup-phone .camera:after {
-  content: "";
-  position: absolute;
-  top: 20%;
-  left: 70%;
-  width: 8px;
-  height: 8px;
-  border-radius: 5px;
-  background-color: #0f0b25;
-}
-
 .mockup-phone .display {
   overflow: hidden;
   border-radius: 40px;
@@ -4305,10 +4269,6 @@ input.tab:checked + .tab-content,
   bottom: 0.25rem;
 }
 
-.bottom-4 {
-  bottom: 1rem;
-}
-
 .left-0 {
   left: 0px;
 }
@@ -4331,10 +4291,6 @@ input.tab:checked + .tab-content,
 
 .right-1 {
   right: 0.25rem;
-}
-
-.right-4 {
-  right: 1rem;
 }
 
 .top-0 {
@@ -4527,11 +4483,6 @@ input.tab:checked + .tab-content,
 
 .hidden {
   display: none;
-}
-
-.size-12 {
-  width: 3rem;
-  height: 3rem;
 }
 
 .size-24 {
@@ -5206,11 +5157,6 @@ input.tab:checked + .tab-content,
 
 .italic {
   font-style: italic;
-}
-
-.text-accent {
-  --tw-text-opacity: 1;
-  color: var(--fallback-a,oklch(var(--a)/var(--tw-text-opacity)));
 }
 
 .text-accent-content {
@@ -6228,6 +6174,12 @@ input.tab:checked + .tab-content,
   padding-inline-start: initial;
 }
 
+/* fix ace-editor cursor misplacement */
+
+#pageCSS-ace *, #pageJS-ace *, #objectHTML-ace * {
+  font: 0.8rem/normal 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'Source Code Pro', 'source-code-pro', monospace !important;
+}
+
 @media (min-width: 768px) {
   @media (hover:hover) {
     .md\:table tr.hover:hover,.md\:table tr.hover:nth-child(even):hover {
@@ -6348,11 +6300,6 @@ input.tab:checked + .tab-content,
   background-color: var(--fallback-a,oklch(var(--a)/var(--tw-bg-opacity)));
 }
 
-.hover\:text-white:hover {
-  --tw-text-opacity: 1;
-  color: rgb(255 255 255 / var(--tw-text-opacity));
-}
-
 .hover\:underline:hover {
   text-decoration-line: underline;
 }
@@ -6464,10 +6411,6 @@ input.tab:checked + .tab-content,
 
   .md\:justify-self-end {
     justify-self: end;
-  }
-
-  .md\:rounded-2xl {
-    border-radius: 1rem;
   }
 
   .md\:rounded-box {

--- a/src/tailwind.input.css
+++ b/src/tailwind.input.css
@@ -126,3 +126,7 @@
   margin-top: initial;
   padding-inline-start: initial;
 }
+/* fix ace-editor cursor misplacement */
+#pageCSS-ace *, #pageJS-ace *, #objectHTML-ace * {
+  font: 0.8rem/normal 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'Source Code Pro', 'source-code-pro', monospace !important;
+}


### PR DESCRIPTION
There was a bug in ace editor which showed a false position of the cursor, and it was very difficult to change the specific part of the code because the user didn't know where the cursor is actually pointing. This was caused by improper use of non -monospace font in the containing div. This commit, for the time being, is forcing the use of proper font inside ace-editor container, but it should be improved by removing the conflicting font-family declarations in creator.css.
tailwind.output.css is also updated.