### PR TITLE
Admin link text without browser notice

### DIFF
--- a/src/legacy/dev-application/controllers/ViewController.php
+++ b/src/legacy/dev-application/controllers/ViewController.php
@@ -783,7 +783,7 @@ class ViewController extends NetActionController
                 }
                 if (@strstr( "{" . $build_[0] . "}", "{adminurl}" )) {
 
-                        $outputDB = str_replace('{adminurl}', '<a href="' . NetActionController::$hostRW . NetActionController::$adminUrl . '" target="_blank">Admin (FF!/Safari/Chrome)</a>' , $outputDB);
+                        $outputDB = str_replace('{adminurl}', '<a href="' . NetActionController::$hostRW . NetActionController::$adminUrl . '" target="_blank">Admin</a>' , $outputDB);
                 }
                 // SEARCH HANDLE
                 if (@strstr( "{" . $build_[0] . "}", "{searchform}" )) {


### PR DESCRIPTION
Admin link should be without browser notice ( written in 2013 ), administrating website in major browsers should not be a problem now, application should work the same on all major browsers.