### PR TITLE
DaisyUI version visible in the admin panel

### DIFF
--- a/src/legacy/dev-application/controllers/CreatorController.php
+++ b/src/legacy/dev-application/controllers/CreatorController.php
@@ -47,6 +47,12 @@ class CreatorController extends NetActionController
             $daisyuiThemes .= '<li><input type="radio" name="theme-dropdown" class="theme-controller btn btn-sm btn-block btn-ghost justify-center" aria-label="' . ucfirst($theme) . '" value="' . $theme . '"/></li>';
         }
 
+        /* get daisyui version from package.json */
+        $package_json = file_get_contents(NET_PATH . "/../../package.json");
+        $daisyui_version = json_decode($package_json);
+
+        $this->view->daisyuiVersion = str_replace('^', '', $daisyui_version->devDependencies->daisyui);
+
         $this->view->daisyuiThemes = $daisyuiThemes;
         isset($_COOKIE['daisyAdminTheme']) ? $this->view->daisyAdminTheme = $_COOKIE['daisyAdminTheme'] : $this->view->daisyAdminTheme = 'nord';
     }

--- a/src/legacy/dev-application/layouts/scripts/login.phtml
+++ b/src/legacy/dev-application/layouts/scripts/login.phtml
@@ -22,7 +22,7 @@
   <title>Creator Login</title>
   <link rel="shortcut icon" type="image/x-icon" href="/images/ide21logo.svg" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0"> 
-  <link href="/css/tailwind.output.css" rel="stylesheet" type="text/css" />
+  <link href="/css/tailwind.output.css?rnd=<?php echo rand();?>" rel="stylesheet" type="text/css" />
   <script src="/daisy/daisyui.tailwind.3.4.3.js"></script>
 </head>
 <body >

--- a/src/legacy/dev-application/layouts/scripts/main-creator.phtml
+++ b/src/legacy/dev-application/layouts/scripts/main-creator.phtml
@@ -151,11 +151,12 @@
         <ul id="daisyui-themes-changer" tabindex="0" class="dropdown-content z-[99] p-2 shadow-2xl bg-base-300 rounded-box w-auto">
           <?php echo $this->daisyuiThemes; ?>
           <li>
-            <a id="add-new-daisy" class="navLinks help theme-controller btn btn-sm btn-block btn-ghost justify-center text-green-600" title="<?php echo $this->translate->_("Manage DaisyUI themes");?>">
+            <a id="add-new-daisy" class="navLinks help theme-controller btn btn-sm btn-block btn-ghost justify-center text-green-600" title="<?php echo $this->translate->_("Manage DaisyUI themes");?> <?php echo $this->daisyuiVersion; ?>">
             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="size-6">
               <path fill-rule="evenodd" d="M12 2.25c-5.385 0-9.75 4.365-9.75 9.75s4.365 9.75 9.75 9.75 9.75-4.365 9.75-9.75S17.385 2.25 12 2.25ZM12.75 9a.75.75 0 0 0-1.5 0v2.25H9a.75.75 0 0 0 0 1.5h2.25V15a.75.75 0 0 0 1.5 0v-2.25H15a.75.75 0 0 0 0-1.5h-2.25V9Z" clip-rule="evenodd" />
             </svg>
             </a>
+            <div id="daisyui-version-cont" class="text-center"><span>DaisyUI</span> <span id="daisyui-version"><?php echo $this->daisyuiVersion; ?></span></div>
           </li>
         </ul>
       </div>

--- a/src/legacy/dev-application/views/scripts/creator/add-new-daisy.phtml
+++ b/src/legacy/dev-application/views/scripts/creator/add-new-daisy.phtml
@@ -43,7 +43,7 @@
           data: { themes: themes }
         }).done(function( msg ) {
 
-            let dropdownToReplace = $('#manage-daisy-themes').html() + '<li><a id="add-new-daisy" class="navLinks help theme-controller btn btn-sm btn-block btn-ghost justify-center text-green-600" title="Manage DaisyUI themes"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="size-6"><path fill-rule="evenodd" d="M12 2.25c-5.385 0-9.75 4.365-9.75 9.75s4.365 9.75 9.75 9.75 9.75-4.365 9.75-9.75S17.385 2.25 12 2.25ZM12.75 9a.75.75 0 0 0-1.5 0v2.25H9a.75.75 0 0 0 0 1.5h2.25V15a.75.75 0 0 0 1.5 0v-2.25H15a.75.75 0 0 0 0-1.5h-2.25V9Z" clip-rule="evenodd"></path></svg></a></li>';
+            let dropdownToReplace = $('#manage-daisy-themes').html() + '<li><a id="add-new-daisy" class="navLinks help theme-controller btn btn-sm btn-block btn-ghost justify-center text-green-600" title="Manage DaisyUI themes v.<?php echo $this->daisyuiVersion; ?>"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="size-6"><path fill-rule="evenodd" d="M12 2.25c-5.385 0-9.75 4.365-9.75 9.75s4.365 9.75 9.75 9.75 9.75-4.365 9.75-9.75S17.385 2.25 12 2.25ZM12.75 9a.75.75 0 0 0-1.5 0v2.25H9a.75.75 0 0 0 0 1.5h2.25V15a.75.75 0 0 0 1.5 0v-2.25H15a.75.75 0 0 0 0-1.5h-2.25V9Z" clip-rule="evenodd"></path></svg></a><div id="daisyui-version-cont" class="text-center"><span>DaisyUI</span> <span id="daisyui-version"><?php echo $this->daisyuiVersion; ?></span></div></li>';
             $('#daisyui-themes-changer').html( dropdownToReplace );
             $('#daisyui-themes-changer').find('.remove-theme').remove();
           });


### PR DESCRIPTION
Unfortunately, DaisyUI 5 themes can not be used for adding/removing in admin panel currently, so the user needs to be notified that only version 4.x themes can be managed, until DaisyUI  version used in the admin panel is upgraded to 5.0.