### PR TITLE
Upgraded Vite to 6.2.6

### DIFF
--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -10,7 +10,7 @@
                 "daisyui": "^4.10.2",
                 "laravel-vite-plugin": "^1.0",
                 "tailwindcss": "^3.4.3",
-                "vite": "^6.2.5"
+                "vite": "^6.2.6"
             }
         },
         "node_modules/@alloc/quick-lru": {
@@ -2277,9 +2277,9 @@
             "dev": true
         },
         "node_modules/vite": {
-            "version": "6.2.5",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.5.tgz",
-            "integrity": "sha512-j023J/hCAa4pRIUH6J9HemwYfjB5llR2Ps0CWeikOtdR8+pAURAk0DoJC5/mm9kd+UgdnIy7d6HE4EAvlYhPhA==",
+            "version": "6.2.6",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.6.tgz",
+            "integrity": "sha512-9xpjNl3kR4rVDZgPNdTL0/c6ao4km69a/2ihNQbcANz8RuCOK3hQBmLSJf3bRKVQjVMda+YvizNE8AwvogcPbw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {

--- a/src/package.json
+++ b/src/package.json
@@ -11,6 +11,6 @@
         "daisyui": "^4.10.2",
         "laravel-vite-plugin": "^1.0",
         "tailwindcss": "^3.4.3",
-        "vite": "^6.2.5"
+        "vite": "^6.2.6"
     }
 }


### PR DESCRIPTION
To address moderate dependabot alert about the previous version of Vite ( 6.2.5 ), Vite was upgraded to 6.2.6