### PR TITLE
Daisy dropdown available with template variable

### DIFF
--- a/src/legacy/dev-application/controllers/CreatorController.php
+++ b/src/legacy/dev-application/controllers/CreatorController.php
@@ -32,15 +32,11 @@ class CreatorController extends NetActionController
         define("NET_PATH_SITE", $this->_nps);
         define("NET_PATH", $this->_np);
 
-        /* get themes from tailwind.config.js */
-        $taiwlindConf = file_get_contents($this->_nps . '../tailwind.config.js'); 
-        $tailwindConfArray = explode('themes:', $taiwlindConf);
-        $tailwindConfArray = explode('[', $tailwindConfArray[1]);
-        $tailwindConfArray = explode(']', $tailwindConfArray[1]);
-        $tailwindConfArray = explode(',',$tailwindConfArray[0]);
+        $tailwindConfArray = NetActionController::getTWConfArray();
+
         $daisyuiThemes = '';
 
-        foreach( $tailwindConfArray as $theme){
+        foreach( $tailwindConfArray as $theme){ // TODO: put this in a partial
             $unwanted = ['"', ' ', "'"];
             $theme =  str_replace($unwanted, '', $theme);
 

--- a/src/legacy/dev-application/controllers/NeTFramework/NetActionController.php
+++ b/src/legacy/dev-application/controllers/NeTFramework/NetActionController.php
@@ -335,6 +335,23 @@ class NetActionController extends Zend_Controller_Action
     }
 
     /**
+     *Get DaisyUI themes installed from tailwind.conf.js
+     *[temporary, should be rewritten, once upgraded to DaisyUI 5 it should be managed very differently]
+     *
+     */
+    public static function getTWConfArray(){
+
+        /* get themes from tailwind.config.js */
+        $taiwlindConf = file_get_contents(NET_PATH . '../../tailwind.config.js');
+        $tailwindConfArray = explode('themes:', $taiwlindConf);
+        $tailwindConfArray = explode('[', $tailwindConfArray[1]);
+        $tailwindConfArray = explode(']', $tailwindConfArray[1]);
+        $tailwindConfArray = explode(',',$tailwindConfArray[0]);
+
+        return $tailwindConfArray;
+    }
+
+    /**
      *Get all languages for inputing new pages or new templates
      *in db
      *

--- a/src/legacy/dev-application/controllers/ViewController.php
+++ b/src/legacy/dev-application/controllers/ViewController.php
@@ -313,6 +313,21 @@ class ViewController extends NetActionController
 
     }
 
+    public static function showDaisyThemeChooser(){
+
+        $themePath = NET_PATH . "widgets/";
+        $view = new Zend_View();
+        $view->addScriptPath($themePath . "templates/");
+
+        $viewArray['tailwindConfArray'] = NetActionController::getTWConfArray();
+
+        $view->assign($viewArray);
+        $scriptName = "daisyThemes.phtml";
+
+        $partialOutput = $view->render($scriptName);
+        return $partialOutput;
+
+    }
 
     public function changeLanguageAction()
     {
@@ -797,6 +812,10 @@ class ViewController extends NetActionController
 
                     $output = ViewController::showLanguageChooser($langsEnabled);
                     $outputDB = str_replace('{language:flags}', $output, $outputDB);
+                }
+                if(@strstr( "{" . $build_[0] . ":themes}" , "{daisyui:themes}")){
+                    $output = ViewController::showDaisyThemeChooser();
+                    $outputDB = str_replace('{daisyui:themes}', $output, $outputDB);
                 }
 
                 // MENU HANDLE

--- a/src/legacy/dev-application/views/scripts/creator/creator.js
+++ b/src/legacy/dev-application/views/scripts/creator/creator.js
@@ -705,22 +705,25 @@ $(document).ready(function(){
   });
   $('#add-new-class-input').livequery('keypress', function(e){
     if(e.which == 13) {
+      $('.tooltip-freeze').removeClass('tooltip-freeze');
       $('#add-new-class').trigger('click'); // add a new class by clicking on a button
       $('#add-new-class-input').focus();
+      $('.selected-for-append').addClass('tooltip-freeze');
     }
   });
 
   // add a new class to the object that ID assistant is pointing to
   $('#add-new-class').livequery('click', function(e){
-    //alert(e);
+    $('.tooltip-freeze').removeClass('tooltip-freeze');
     $( '#' + $('#assistant-target-id').text()).addClass($('#add-new-class-input').val());
     $( '#' + $('#assistant-target-id').text()).trigger('mouseover');
+    $('.selected-for-append').addClass('tooltip-freeze');
   });
 
   //TURN ID ASSISTANT on/off
   $('#tttoggle').prop('checked', false); // uncheck by default
   $('#tttoggle').livequery('click', function(){
-
+    $('.tooltip-freeze').removeClass('tooltip-freeze');
     if ($(this).prop("checked") == true) {
       tooltipShow = 1;
       // dialog
@@ -918,7 +921,7 @@ $(document).ready(function(){
     $('#objList').append('<option>net_' + newObjId + '</option>');
 
     refreshControls();
-    $('#net_' + newObjId  ).css({left:$('#net_' + newObjId  ).position().left + 5, top:$('#net_' + newObjId  ).position().top +5 });
+    //$('#net_' + newObjId  ).css({left:$('#net_' + newObjId  ).position().left + 5, top:$('#net_' + newObjId  ).position().top +5 });
 
     $('#net_' + newObjId  ).dblclick();
     newIt++;

--- a/src/legacy/dev-application/views/scripts/creator/creator.js
+++ b/src/legacy/dev-application/views/scripts/creator/creator.js
@@ -712,6 +712,7 @@ $(document).ready(function(){
 
   // add a new class to the object that ID assistant is pointing to
   $('#add-new-class').livequery('click', function(e){
+    //alert(e);
     $( '#' + $('#assistant-target-id').text()).addClass($('#add-new-class-input').val());
     $( '#' + $('#assistant-target-id').text()).trigger('mouseover');
   });
@@ -731,7 +732,7 @@ $(document).ready(function(){
         $('#tooltip').appendTo('#dialogDiv_assistant');
 
         $('#dialogDiv_assistant' ).dialog({modal: false, resizable: true, title: 'ID Assistant', closeOnEscape: false,
-          position: { my: "left top", at: "left bottom", of: '#objList' },
+          position: { my: "left top", at: "left top", of: '#wrap_new_objType' },
           width: $('#objList').outerWidth(),
           beforeClose: function(event, ui) {
           $('#tooltip').appendTo('body');

--- a/src/legacy/dev-application/widgets/templates/daisyThemes.phtml
+++ b/src/legacy/dev-application/widgets/templates/daisyThemes.phtml
@@ -1,0 +1,17 @@
+<div class="dropdown relative left-1" style="z-index:9;" title="">
+    <div tabindex="0" role="button" class="btn btn-sm min-h-8 h-8 w-8 rounded-full">
+        <svg width="12px" height="12px" class="h-2 w-2 fill-current opacity-60 inline-block" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2048 2048"><path d="M1799 349l242 241-1017 1017L7 590l242-241 775 775 775-775z"></path></svg>
+    </div>
+    <ul id="daisyui-themes-changer" tabindex="0" class="dropdown-content z-[99] p-2 shadow-2xl bg-base-300 rounded-box w-auto">
+        <?php
+        $daisyuiThemes = '';
+        foreach( $this->tailwindConfArray as $theme){
+            $unwanted = ['"', ' ', "'"];
+            $theme =  str_replace($unwanted, '', $theme);
+
+            $daisyuiThemes .= '<li><input type="radio" name="theme-dropdown" class="theme-controller btn btn-sm btn-block btn-ghost justify-center" aria-label="' . ucfirst($theme) . '" value="' . $theme . '"/></li>';
+        }
+        echo $daisyuiThemes;
+        ?>
+    </ul>
+</div>


### PR DESCRIPTION
To be able to update the list of installed DaisyUI themes in the website part, a template variable {daisyui:themes} was created. Now when a theme is added or removed the updated list  can be automatically shown in the dropdown, no matter where on the page it is displayed, and without the need to update the html of the object manually.
Also a bug with ID assistant where it did not update the list of classes on add, was fixed.