### PR TITLE
Hide Deprecated warnings in Zend applicaton

### DIFF
--- a/src/legacy/indexZend.php
+++ b/src/legacy/indexZend.php
@@ -18,7 +18,7 @@
 /** Bootstrap */
 /** Setting error reporting */
 //error_reporting(E_ALL | E_STRICT);
-error_reporting(E_ALL );
+error_reporting( E_ALL  & ~E_DEPRECATED );
 ini_set('display_startup_errors', 1);
 ini_set('display_errors', 1);
 


### PR DESCRIPTION
No deprecated warnings should be shown, disabled the setting in src/legacy/indexZend.php.