### PR TITLE
Selected object marked with outline

### DIFF
--- a/src/legacy/dev-application/views/scripts/creator/creator.js
+++ b/src/legacy/dev-application/views/scripts/creator/creator.js
@@ -858,12 +858,12 @@ $(document).ready(function(){
       // insert inside selected object - TODO
 
       // insertAfter selected object
-      $("\n" + '<div class="draggable" id="'+newObjId+'" style="border:1px dotted red;z-index:' + zIndexCounter + '">' + "\n\t" + '<p class="objContent">NeT.Object ' + newObjId + "\n\t" + '</p>' + "\n" + '</div>'+ "\n").insertAfter(droppableContainer);
+      $("\n" + '<div class="draggable" id="'+newObjId+'" style="z-index:' + zIndexCounter + '">' + "\n\t" + '<p class="objContent">NeT.Object ' + newObjId + "\n\t" + '</p>' + "\n" + '</div>'+ "\n").insertAfter(droppableContainer);
     } else {
 
       droppableContainer = "#droppable";
       // insert inside #droppable
-      $(droppableContainer).append("\n" + '<div class="draggable" id="'+newObjId+'" style="border:1px dotted red;z-index:' + zIndexCounter + '">' + "\n\t" + '<p class="objContent">NeT.Object ' + newObjId + "\n\t" + '</p>' + "\n" + '</div>'+ "\n");
+      $(droppableContainer).append("\n" + '<div class="draggable" id="'+newObjId+'" style="z-index:' + zIndexCounter + '">' + "\n\t" + '<p class="objContent">NeT.Object ' + newObjId + "\n\t" + '</p>' + "\n" + '</div>'+ "\n");
     }
 
     //IF CONTAINER ON, THEN ADD class IN THE CURRENT OBJECT, ELSE the same
@@ -944,7 +944,6 @@ $(document).ready(function(){
     }
     $(".draggable").each(function(){
       $(this).removeClass("inactiveObject");
-      $(this).css("border", "0");
 
       //if it is a menu write command
       /*if ($(this).attr("objtype") == "Menu"){
@@ -999,7 +998,7 @@ $(document).ready(function(){
     }
 
     $(".draggable").each(function(){
-      $(this).css("border", "0");
+
       $(this).removeClass("inactiveObject");
 
       //if it is a menu write command
@@ -1153,7 +1152,7 @@ $(document).ready(function(){
     $('*[contenteditable="true"]').attr('contenteditable', 'false');
 
     $(".draggable").each(function(){
-      $(this).css("border", "0");
+
       $(this).removeClass("inactiveObject");
       $(this).addClass("templateDiv");
       //if it is a menu write command
@@ -1194,7 +1193,6 @@ $(document).ready(function(){
     $('*[contenteditable="true"]').attr('contenteditable', 'false');
 
     $(".draggable:not('.templateDiv')").each(function(){
-      $(this).css("border", "0");
 
       $(this).removeClass("inactiveObject");
       $(this).addClass("templateDiv");

--- a/src/tailwind.input.css
+++ b/src/tailwind.input.css
@@ -53,13 +53,13 @@ select:not(.paginationStep) { display: none; }
 
 /* with selecting the specific div inside template or page, user should be able to insert a new object directly into it */
 #droppable * {
-  @apply border border-dashed border-transparent !important;
+  /*@apply border border-dashed border-transparent !important;*/
 }
 #droppable *:hover {
-  @apply border border-dashed border-lime-800 !important;
+  @apply outline outline-[1px] outline-dashed -outline-offset-2 outline-accent;
 }
 #droppable *.selected-for-append {
-  @apply border border-dashed border-red-500 !important;
+  @apply outline outline-[4px] outline-dashed -outline-offset-4 outline-accent !important;
 }
 /* this marks the specific div to be visible as the div where the new object is to be appended */
 


### PR DESCRIPTION
Selected objects and new objects were marked with a red border until now. Borders should be available to the users to customize them in the way that they want, so now we are using outline for marking the selected and new objects, and the outline has the color that selected DaisyUI theme defines as 'accent'.
The coloring of the outline is something that should be considered again, to have something unified, and also the use of the outline itself for marking the object, but for now we go with the outline.

![outline-nord](https://github.com/user-attachments/assets/3dab07d7-46fd-402c-bbbe-d1ffd9d34372)
![outline-retro](https://github.com/user-attachments/assets/72110fc9-2c71-458b-9c9a-af94af0a44d2)

