### PR TITLE
Added .md files in apache2 and data folders

### DIFF
--- a/apache2/REPLACE-THESE-FILES-WITH-YOUR-OWN.md
+++ b/apache2/REPLACE-THESE-FILES-WITH-YOUR-OWN.md
@@ -1,0 +1,3 @@
+# REPLACE THE FILES
+
+The files in this folder are here to enable speedy start of the app on https://localhost during development, and are meant to be replaced with your own files for any other use.

--- a/data/README-FIRST.md
+++ b/data/README-FIRST.md
@@ -1,0 +1,5 @@
+# DEFAULT DATABASE
+
+This is the default data folder that contains MariaDB database files used for starting the app on localhost, to have a speedy development setup with Docker by using it in docker-compose.yaml, and you should only use it for development.
+
+In production you should always have your own database, credentials, data folder paths pointing to this folder in docker-compose.yaml.


### PR DESCRIPTION
To make it clear that the files in apache2 and data folders are there to enable the speedy start of the app on https://localhost, and are not meant to be used for purposes other than development, two .md files are added in those folders.