### PR TITLE
Added new translation strings in javascript files

### DIFF
--- a/src/legacy/dev-application/views/scripts/creator/creator.js
+++ b/src/legacy/dev-application/views/scripts/creator/creator.js
@@ -703,10 +703,10 @@ $(document).ready(function(){
       const objectClasses = '<div class="grid grid-cols-2 gap-2 bg-base-100 p-2">' + objectClassesFields + '</div>';
 
       // Add New Class input field and button
-      const addNewClass = '<div class="grid gap-2"><input id="add-new-class-input" type="text" class="input input-sm mt-2" /><button id="add-new-class" class="btn btn-sm bg-neutral text-neutral-content btn-ghost">Add</button></div>'
+      const addNewClass = '<div class="grid gap-2"><input id="add-new-class-input" type="text" class="input input-sm w-full mt-2" /><button id="add-new-class" class="btn btn-sm bg-neutral text-neutral-content btn-ghost">' + lang.Add + '</button></div>'
 
       // finaly put it all together
-      $('#tooltip').html( '<div id="assistant-target-id" class="text-normal font-semibold">' + $(e.target).attr("id") + '</div>' + objectClasses + addNewClass );
+      $('#tooltip').html( '<div class="mb-2 bg-neutral text-neutral-content px-2 rounded"><span>ID: </span><span id="assistant-target-id" class="text-normal font-semibold">' + $(e.target).attr("id") + '</span></div>' + objectClasses + addNewClass );
 
       $('#tooltip').appendTo('#dialogDiv_assistant');
 
@@ -757,10 +757,10 @@ $(document).ready(function(){
 
       if($('#dialogDiv_assistant' ).length < 1 ){
 
-        $('body').append('<div data-theme="' + daisyAdminTheme + '" class="dialogDiv bg-base-100 text-base-content" id="dialogDiv_assistant" ><p>Select the object to see its classes</p></div>');
+        $('body').append('<div data-theme="' + daisyAdminTheme + '" class="dialogDiv bg-base-100 text-base-content" id="dialogDiv_assistant" ><div class="mb-4">' + lang.IdAssistantInitialContent + '</div></div>');
         $('#tooltip').appendTo('#dialogDiv_assistant');
 
-        $('#dialogDiv_assistant' ).dialog({modal: false, resizable: true, title: 'ID Assistant', closeOnEscape: false,
+        $('#dialogDiv_assistant' ).dialog({modal: false, resizable: true, title: lang.IdAssistantDialogTitle, closeOnEscape: false,
           position: { my: "left top", at: "left top", of: '#wrap_new_objType' },
           width: $('#objList').outerWidth(),
           beforeClose: function(event, ui) {

--- a/src/public/js/language/creator/de.js
+++ b/src/public/js/language/creator/de.js
@@ -1,6 +1,6 @@
 var lang = new Object();
 
-lang.Loading	 = "laden ...";
+lang.Loading	 = "";
 lang.Working	 = "arbeiten ...";
 lang.AYS	 = "Sind Sie sicher?";
 lang.Done	 = "Fertig!";
@@ -35,5 +35,7 @@ lang.AYSdelPag	 = "Sind Sie sicher, dass Sie diese Seite löschen wollen?";
 lang.FolderAdded	 = "Ordner hinzugefügt!";
 lang.FileUploaded	 = "Datei heruntergeladen!";
 lang.CatNameTr	 = "Übersetzung der Kategorie-Name";
-
 lang.TemplateInstalled = "Vorlage installiert!";
+lang.IdAssistantDialogTitle = "ID/Klassen-Assistent";
+lang.IdAssistantInitialContent = "Wählen Sie das Objekt aus, um seine Klassen anzuzeigen.";
+lang.Add = "Hinzufügen";

--- a/src/public/js/language/creator/en.js
+++ b/src/public/js/language/creator/en.js
@@ -36,3 +36,6 @@ lang.FolderAdded = "Folder Added!";
 lang.FileUploaded = "File uploaded!";
 lang.CatNameTr = "Category Name Translation";
 lang.TemplateInstalled = "Template Installed!";
+lang.IdAssistantDialogTitle = "ID/Classes assistant";
+lang.IdAssistantInitialContent = "Select the object to see its classes.";
+lang.Add = "Add";

--- a/src/public/js/language/creator/es.js
+++ b/src/public/js/language/creator/es.js
@@ -35,5 +35,7 @@ lang.AYSdelPag	 = "¿Está seguro que desea eliminar estas páginas?";
 lang.FolderAdded	 = "Registro añadido!";
 lang.FileUploaded	 = "Subida de archivos!";
 lang.CatNameTr	 = "Traducción Nombre Categoría";
-
-lang.TemplateInstalled = "Template Installed!";
+lang.TemplateInstalled = "¡Plantilla instalada!";
+lang.IdAssistantDialogTitle = "Asistente de ID/Clases";
+lang.IdAssistantInitialContent = "Seleccione el objeto para ver sus clases.";
+lang.Add = "Añadir";

--- a/src/public/js/language/creator/fi.js
+++ b/src/public/js/language/creator/fi.js
@@ -36,3 +36,6 @@ lang.FolderAdded = "Kansio on lisätty";
 lang.FileUploaded = "Tiedosto on siirretty palvelimeen";
 lang.CatNameTr = "Luokan nimen käännös";
 lang.TemplateInstalled = "Mallipohja on asennettu";
+lang.IdAssistantDialogTitle = "ID/Luokat-avustaja";
+lang.IdAssistantInitialContent = "Valitse objekti nähdäksesi sen luokat.";
+lang.Add = "Lisää";

--- a/src/public/js/language/creator/fr.js
+++ b/src/public/js/language/creator/fr.js
@@ -35,5 +35,7 @@ lang.AYSdelPag	 = "Etes-vous sûr de vouloir supprimer ces pages?";
 lang.FolderAdded	 = "Dossier ajouté!";
 lang.FileUploaded	 = "Fichier téléchargé!";
 lang.CatNameTr	 = "Traduction Nom de la catégorie";
-
 lang.TemplateInstalled = "Template Installed!";
+lang.IdAssistantDialogTitle = "Assistant ID/Classes";
+lang.IdAssistantInitialContent = "Sélectionnez l'objet pour afficher ses classes.";
+lang.Add = "Ajouter";

--- a/src/public/js/language/creator/hi.js
+++ b/src/public/js/language/creator/hi.js
@@ -36,3 +36,6 @@ lang.FolderAdded = "फोल्डर जोड़ा गया!";
 lang.FileUploaded = "फाइल अपलोड की गई!";
 lang.CatNameTr = "श्रेणी नाम अनुवाद";
 lang.TemplateInstalled = "टेम्प्लेट स्थापित!";
+lang.IdAssistantDialogTitle = "ID/कक्षा सहायक";
+lang.IdAssistantInitialContent = "ऑब्जेक्ट की कक्षाएँ देखने के लिए उसे चुनें।";
+lang.Add = "जोड़ें";

--- a/src/public/js/language/creator/hu.js
+++ b/src/public/js/language/creator/hu.js
@@ -35,5 +35,7 @@ lang.AYSdelPag	 = "Biztos benne, hogy törölni szeretné ezeket az oldalakat?";
 lang.FolderAdded	 = "Record hozzá!";
 lang.FileUploaded	 = "File letöltés!";
 lang.CatNameTr	 = "Fordítás Kategória neve";
-
 lang.TemplateInstalled = "Template Installed!";
+lang.IdAssistantDialogTitle = "Azonosító/Osztályok asszisztens";
+lang.IdAssistantInitialContent = "Válassza ki az objektumot az osztályainak megtekintéséhez."
+lang.Add = "Hozzáadás";

--- a/src/public/js/language/creator/it.js
+++ b/src/public/js/language/creator/it.js
@@ -35,5 +35,7 @@ lang.AYSdelPag	 = "Sei sicuro di voler eliminare queste pagine?";
 lang.FolderAdded	 = "Record aggiunto!";
 lang.FileUploaded	 = "File download!";
 lang.CatNameTr	 = "Traduzione Categoria Nome";
-
 lang.TemplateInstalled = "Template Installed!";
+lang.IdAssistantDialogTitle = "Assistente ID/Classi";
+lang.IdAssistantInitialContent = "Seleziona l'oggetto per visualizzarne le classi.";
+lang.Add = "Aggiungi";

--- a/src/public/js/language/creator/ja.js
+++ b/src/public/js/language/creator/ja.js
@@ -35,5 +35,7 @@ lang.AYSdelPag	 = "あなたはあなたがこれらのページを削除しま�
 lang.FolderAdded	 = "フォルダを追加しました！";
 lang.FileUploaded	 = "ファイルがアップロード！";
 lang.CatNameTr	 = "翻訳カテゴリー名";
-
-lang.TemplateInstalled = "Template Installed!";
+lang.TemplateInstalled = "テンプレートがインストールされました！";
+lang.IdAssistantDialogTitle = "ID/クラスアシスタント";
+lang.IdAssistantInitialContent = "オブジェクトを選択してそのクラスを確認してください。";
+lang.Add = "追加";

--- a/src/public/js/language/creator/pt.js
+++ b/src/public/js/language/creator/pt.js
@@ -35,5 +35,7 @@ lang.AYSdelPag = "Você tem certeza de que deseja excluir estas páginas?";
 lang.FolderAdded = "Pasta adicionada!";
 lang.FileUploaded = "Arquivo enviado!";
 lang.CatNameTr = "Tradução do nome da categoria";
-
 lang.TemplateInstalled = "Template instalado!";
+lang.IdAssistantDialogTitle = "Assistente de ID/Classes";
+lang.IdAssistantInitialContent = "Selecione o objeto para ver suas classes.";
+lang.Add = "Adicionar";

--- a/src/public/js/language/creator/ru.js
+++ b/src/public/js/language/creator/ru.js
@@ -34,6 +34,8 @@ lang.Changing	 = "Изменить ...";
 lang.AYSdelPag	 = "Вы уверены, что хотите удалить эти страницы?";
 lang.FolderAdded	 = "Файл добавлено!";
 lang.FileUploaded	 = "Файл загрузили!";
-lang.CatNameTr	 = "Название Перевод Категория";
-
-lang.TemplateInstalled = "Template Installed!";
+lang.CatNameTr = "Название Перевод Категория";
+lang.TemplateInstalled = "Шаблон установлен!";
+lang.IdAssistantDialogTitle = "ID/Классы помощника";
+lang.IdAssistantInitialContent = "Выберите объект, чтобы увидеть его классы.";
+lang.Add = "Добавить";

--- a/src/public/js/language/creator/sr.js
+++ b/src/public/js/language/creator/sr.js
@@ -35,5 +35,7 @@ lang.AYSdelPag = "Jeste li sigurni da želite da obrišete ove strane?";
 lang.FolderAdded = "Folder je dodat!";
 lang.FileUploaded = "Fajl je uploadovan!";
 lang.CatNameTr = "Prevod imena kategorije";
-
 lang.TemplateInstalled = "Templejt je instaliran!";
+lang.IdAssistantDialogTitle = "ID/Class asistent";
+lang.IdAssistantInitialContent = "Izaberite objekat da biste videli njegove klase.";
+lang.Add = "Dodaj";


### PR DESCRIPTION
For existing languages, new translation strings are added, which are used for ID Assistant dialog.
All the javascript translation should be moved to a unified php translation file at some point, once php translation is switched to Laravel version if not sooner.