### PR TITLE
Added 'Pagination step' translation to all the languages in the admin

### DIFF
--- a/src/legacy/dev-application/languages/creator/de.php
+++ b/src/legacy/dev-application/languages/creator/de.php
@@ -306,4 +306,5 @@ return array(
     "Choose gallery:" => "Galerie wählen:",
     "Select the template for this page" => "Template für die Seite auswählen",
     "Only superadministrator can delete this!" => "Nur der Superadministrator kann dies löschen!",
+    "Pagination step ( default 10 )" => "Paginierungsschritt ( Standardwert 10 )",
 );

--- a/src/legacy/dev-application/languages/creator/en.php
+++ b/src/legacy/dev-application/languages/creator/en.php
@@ -306,4 +306,5 @@ return array(
     "Click here to download all revisions of this template" => "Click here to download all revisions of this template",
     "Install" => "Install",
     "Browse a template" => "Browse a template",
+    "Pagination step ( default 10 )" => "Pagination step ( default 10 )",
 );

--- a/src/legacy/dev-application/languages/creator/es.php
+++ b/src/legacy/dev-application/languages/creator/es.php
@@ -309,4 +309,5 @@ return array (
     "Click here to download all revisions of this template" => "Haga clic aquí para descargar todas las revisiones de esta plantilla",
     "Install" => "Instalar",
     "Browse a template" => "Explorar una plantilla",
+    "Pagination step ( default 10 )" => "Paso de paginación (predeterminado 10)",
 );

--- a/src/legacy/dev-application/languages/creator/fi.php
+++ b/src/legacy/dev-application/languages/creator/fi.php
@@ -312,4 +312,5 @@ return array(
     "Click here to download all revisions of this template" => "Lataa kaikki mallipohjan versiot napsauttamalla tätä",
     "Install" => "Asenna",
     "Browse a template" => "Valitse mallipohja selaamalla",
+    "Pagination step ( default 10 )" => "Sivutusväli ( oletus 10 )",
 );

--- a/src/legacy/dev-application/languages/creator/hi.php
+++ b/src/legacy/dev-application/languages/creator/hi.php
@@ -306,4 +306,5 @@ return array(
     "Click here to download all revisions of this template" => "इस टेम्पलेट के सभी संशोधनों को डाउनलोड करने के लिए यहां क्लिक करें",
     "Install" => "स्थापित करें",
     "Browse a template" => "टेम्पलेट विचरण करें",
+    "Pagination step ( default 10 )" => "पृष्ठांकन चरण (डिफ़ॉल्ट 10)",
 );

--- a/src/legacy/dev-application/languages/creator/hu.php
+++ b/src/legacy/dev-application/languages/creator/hu.php
@@ -247,4 +247,5 @@ return array(
     "Menu item" => "Menüpont",
     "edited!" => "szerkesztett!",
     "This Page is deleted!" => "Ez az oldal törölve!",
+    "Pagination step ( default 10 )" => "Oldalszámozási lépés (alapértelmezett 10)",
 );

--- a/src/legacy/dev-application/languages/creator/it.php
+++ b/src/legacy/dev-application/languages/creator/it.php
@@ -247,4 +247,5 @@ return array (
     "Menu item" => "Voce di menu",
     "edited!" => "a cura!",
     "This Page is deleted!" => "Questa pagina è cancellato!",
+    "Pagination step ( default 10 )" => "Passo di paginazione (predefinito 10)",
 );

--- a/src/legacy/dev-application/languages/creator/ja.php
+++ b/src/legacy/dev-application/languages/creator/ja.php
@@ -247,4 +247,5 @@ return array(
     "Menu item" => "メニュー項目",
     "edited!" => "編集！",
     "This Page is deleted!" => "このページは削除されます！",
+    "Pagination step ( default 10 )" => "ページ区切りステップ（デフォルト10）",
 );

--- a/src/legacy/dev-application/languages/creator/pt.php
+++ b/src/legacy/dev-application/languages/creator/pt.php
@@ -311,4 +311,5 @@ return array(
     "Click here to download all revisions of this template" => "Clique aqui para baixar todas as revisões deste modelo",
     "Install" => "Instalar",
     "Browse a template" => "Procurar um modelo",
+    "Pagination step ( default 10 )" => "Etapa de paginação (padrão 10)",
 );

--- a/src/legacy/dev-application/languages/creator/ru.php
+++ b/src/legacy/dev-application/languages/creator/ru.php
@@ -247,4 +247,5 @@ return array(
     "Menu item" => "Пункт меню",
     "edited!" => "редактировать!",
     "This Page is deleted!" => "Эта страница удалена!",
+    "Pagination step ( default 10 )" => "Шаг пагинации (по умолчанию 10)",
 );

--- a/src/legacy/dev-application/languages/creator/sr.php
+++ b/src/legacy/dev-application/languages/creator/sr.php
@@ -306,4 +306,5 @@ return array(
     "Click here to download all revisions of this template" => "Klikni za download svih revizija ovog templejta",
     "Install" => "Instaliraj",
     "Browse a template" => "Potraži templejt",
+    "Pagination step ( default 10 )" => "Korak paginacije ( početno 10 )",
 );

--- a/src/legacy/dev-application/languages/creator/tr.php
+++ b/src/legacy/dev-application/languages/creator/tr.php
@@ -306,4 +306,5 @@ return array(
     "Click here to download all revisions of this template" => "Bu şablonun tüm revizyonlarını indirmek için buraya tıklayın",
     "Install" => "Yükle",
     "Browse a template" => "Şablonlara gözat",
+    "Pagination step ( default 10 )" => "Sayfalama adımı (varsayılan 10)",
 );


### PR DESCRIPTION
The string 'Pagination step ( default 10 )'  was missed in the initial missing string scan that put all the missing strings into their respective .missing files, because widgets folder was not included in the scan. I've added it to all the languages available in the admin panel.